### PR TITLE
Make sample methods take io.Reader

### DIFF
--- a/pkg/hash/commit.go
+++ b/pkg/hash/commit.go
@@ -34,7 +34,7 @@ func (hash *Hash) Commit(id party.ID, data ...interface{}) (Commitment, Decommit
 
 	_, _ = h.Write(decommitment)
 
-	commitment, _ := h.ReadBytes(nil)
+	commitment := h.ReadBytes(nil)
 
 	return commitment, decommitment, nil
 }
@@ -57,7 +57,7 @@ func (hash *Hash) Decommit(id party.ID, c Commitment, d Decommitment, data ...in
 
 	_, _ = h.Write(d)
 
-	computedCommitment, _ := h.ReadBytes(nil)
+	computedCommitment := h.ReadBytes(nil)
 
 	return bytes.Equal(computedCommitment, c)
 }

--- a/pkg/hash/hash.go
+++ b/pkg/hash/hash.go
@@ -110,7 +110,7 @@ func (hash *Hash) Clone() *Hash {
 
 // CloneWithID returns a copy of the Hash in its current state, but also writes the ID to the new state.
 func (hash *Hash) CloneWithID(id party.ID) *Hash {
-	h2 := hash.h.Clone()
-	_, _ = h2.Write([]byte(id))
-	return &Hash{h: h2}
+	cloned := hash.Clone()
+	cloned.Write([]byte(id))
+	return cloned
 }

--- a/pkg/hash/hash.go
+++ b/pkg/hash/hash.go
@@ -30,15 +30,6 @@ func (hash *Hash) Read(buf []byte) (n int, err error) {
 	return hash.h.Read(buf)
 }
 
-// ReadScalar generates a curve.Scalar by reading from hash.Hash.
-// To prevent statistical bias, we sample double the size.
-func (hash *Hash) ReadScalar() *curve.Scalar {
-	var scalar curve.Scalar
-	out := make([]byte, params.BytesScalar)
-	_, _ = hash.h.Read(out)
-	return scalar.SetBytes(out)
-}
-
 // ReadFqNegative generates a big.Int in the interval ±q, by reading from hash.Hash.
 func (hash *Hash) ReadFqNegative() *big.Int {
 	var n big.Int

--- a/pkg/hash/hash.go
+++ b/pkg/hash/hash.go
@@ -11,7 +11,10 @@ import (
 	"golang.org/x/crypto/sha3"
 )
 
-// Hash is a wrapper for sha3.ShakeHash which extends its functionality to work with CMP's data types.
+// Hash is the hash function we use for generating commitments, consuming CMP types, etc.
+//
+// Internally, this is a wrapper around sha3.ShakeHash, but any hash function with
+// an easily extendable output would work as well.
 type Hash struct {
 	h sha3.ShakeHash
 }

--- a/pkg/hash/hash.go
+++ b/pkg/hash/hash.go
@@ -30,24 +30,6 @@ func (hash *Hash) Read(buf []byte) (n int, err error) {
 	return hash.h.Read(buf)
 }
 
-// ReadFqNegative generates a big.Int in the interval ±q, by reading from hash.Hash.
-func (hash *Hash) ReadFqNegative() *big.Int {
-	var n big.Int
-	out := make([]byte, params.BytesScalar+1)
-	_, _ = hash.h.Read(out)
-
-	// use the first byte to determine if the result should be negative
-	isNeg := (out[0] & 1) == 1
-	out = out[1:]
-
-	n.SetBytes(out)
-	if isNeg {
-		n.Neg(&n)
-	}
-
-	return &n
-}
-
 // ReadBytes returns numBytes by reading from hash.Hash.
 // if in is nil, ReadBytes returns the minimum safe length
 func (hash *Hash) ReadBytes(in []byte) ([]byte, error) {

--- a/pkg/hash/hash.go
+++ b/pkg/hash/hash.go
@@ -128,6 +128,6 @@ func (hash *Hash) Clone() *Hash {
 // CloneWithID returns a copy of the Hash in its current state, but also writes the ID to the new state.
 func (hash *Hash) CloneWithID(id party.ID) *Hash {
 	cloned := hash.Clone()
-	cloned.Write([]byte(id))
+	_, _ = cloned.Write([]byte(id))
 	return cloned
 }

--- a/pkg/hash/hash.go
+++ b/pkg/hash/hash.go
@@ -22,6 +22,14 @@ func New() *Hash {
 	return hash
 }
 
+// Read makes Hash implement the io.Reader interface.
+//
+// Implementing this interface is convenient in ZK proofs, which need to use the
+// output of a hash function as randomness later on.
+func (hash *Hash) Read(buf []byte) (n int, err error) {
+	return hash.h.Read(buf)
+}
+
 // ReadScalar generates a curve.Scalar by reading from hash.Hash.
 // To prevent statistical bias, we sample double the size.
 func (hash *Hash) ReadScalar() *curve.Scalar {

--- a/pkg/hash/hash.go
+++ b/pkg/hash/hash.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"math/big"
 
-	"github.com/taurusgroup/cmp-ecdsa/pkg/math/curve"
 	"github.com/taurusgroup/cmp-ecdsa/pkg/params"
 	"github.com/taurusgroup/cmp-ecdsa/pkg/party"
 	"golang.org/x/crypto/sha3"
@@ -72,22 +71,6 @@ func (hash *Hash) WriteAny(data ...interface{}) (int64, error) {
 				return n, fmt.Errorf("hash.Hash: write []byte: %w", err)
 			}
 			n += int64(n0)
-		case []*curve.Point:
-			for _, p := range t {
-				n0, err := p.WriteTo(hash)
-				n += n0
-				if err != nil {
-					return n, fmt.Errorf("hash.Hash: write []*curve.Point: %w", err)
-				}
-			}
-		case []curve.Point:
-			for _, p := range t {
-				n0, err := p.WriteTo(hash)
-				n += n0
-				if err != nil {
-					return n, fmt.Errorf("hash.Hash: write []curve.Point: %w", err)
-				}
-			}
 		case *big.Int:
 			if t == nil {
 				return n, fmt.Errorf("hash.Hash: write *big.Int: nil")

--- a/pkg/hash/hash.go
+++ b/pkg/hash/hash.go
@@ -30,23 +30,28 @@ func (hash *Hash) Read(buf []byte) (n int, err error) {
 	return hash.h.Read(buf)
 }
 
-// ReadBytes returns numBytes by reading from hash.Hash.
-// if in is nil, ReadBytes returns the minimum safe length
-func (hash *Hash) ReadBytes(in []byte) ([]byte, error) {
+// ReadBytes fills a buffer with bytes.
+//
+// If in is nil, then the default number of bytes are read into a new buffer.
+//
+// Otherwise, in is filled with exactly the right number of bytes.
+//
+// This function will panic if in is smaller than a safe number of bytes.
+func (hash *Hash) ReadBytes(in []byte) []byte {
 	if in == nil {
 		in = make([]byte, params.HashBytes)
 	}
 	if len(in) < params.HashBytes {
-		panic("hash.ReadBytes: tried to read less than 256 bits")
+		panic(fmt.Sprintf("hash.ReadBytes: tried to read less than %d bits", 8*params.HashBytes))
 	}
-	_, err := hash.h.Read(in)
-	if err != nil {
-		return nil, err
+	if _, err := hash.Read(in); err != nil {
+		panic(fmt.Sprintf("hash.ReadBytes: internal hash failure: %v", err))
 	}
-	return in, err
+	return in
 }
 
 // Write writes data to the hash state.
+//
 // Implements io.Writer
 func (hash *Hash) Write(data []byte) (int, error) {
 	// the underlying hash function never returns an error

--- a/pkg/hash/hash_test.go
+++ b/pkg/hash/hash_test.go
@@ -1,6 +1,7 @@
 package hash
 
 import (
+	"crypto/rand"
 	"math/big"
 	"testing"
 
@@ -28,11 +29,11 @@ func TestHash_WriteAny(t *testing.T) {
 		}
 	}
 
-	X := curve.NewIdentityPoint().ScalarBaseMult(sample.Scalar())
+	X := curve.NewIdentityPoint().ScalarBaseMult(sample.Scalar(rand.Reader))
 	a([]*curve.Point{X, X, X, X})
 
 	a(big.NewInt(35))
-	a(curve.NewIdentityPoint().ScalarBaseMult(sample.Scalar()))
+	a(curve.NewIdentityPoint().ScalarBaseMult(sample.Scalar(rand.Reader)))
 	a([]byte{1, 4, 6})
 
 	b(big.NewInt(35), []byte{1, 4, 6})

--- a/pkg/hash/hash_test.go
+++ b/pkg/hash/hash_test.go
@@ -29,9 +29,6 @@ func TestHash_WriteAny(t *testing.T) {
 		}
 	}
 
-	X := curve.NewIdentityPoint().ScalarBaseMult(sample.Scalar(rand.Reader))
-	a([]*curve.Point{X, X, X, X})
-
 	a(big.NewInt(35))
 	a(curve.NewIdentityPoint().ScalarBaseMult(sample.Scalar(rand.Reader)))
 	a([]byte{1, 4, 6})

--- a/pkg/math/polynomial/exponent_test.go
+++ b/pkg/math/polynomial/exponent_test.go
@@ -1,6 +1,7 @@
 package polynomial
 
 import (
+	"crypto/rand"
 	"fmt"
 	"testing"
 
@@ -15,12 +16,12 @@ func TestExponent_Evaluate(t *testing.T) {
 		N := 1000
 		var secret *curve.Scalar
 		if x%2 == 0 {
-			secret = sample.Scalar()
+			secret = sample.Scalar(rand.Reader)
 		}
 		poly := NewPolynomial(N, secret)
 		polyExp := NewPolynomialExponent(poly)
 
-		randomIndex := sample.Scalar()
+		randomIndex := sample.Scalar(rand.Reader)
 
 		lhs.ScalarBaseMult(poly.Evaluate(randomIndex))
 		rhs1 := polyExp.evaluateHorner(randomIndex)
@@ -36,7 +37,7 @@ func TestSum(t *testing.T) {
 	N := 20
 	Deg := 10
 
-	randomIndex := sample.Scalar()
+	randomIndex := sample.Scalar(rand.Reader)
 
 	// compute f1(x) + f2(x) + …
 	evaluationScalar := curve.NewScalar()
@@ -47,7 +48,7 @@ func TestSum(t *testing.T) {
 	polys := make([]*Polynomial, N)
 	polysExp := make([]*Exponent, N)
 	for i := range polys {
-		sec := sample.Scalar()
+		sec := sample.Scalar(rand.Reader)
 		polys[i] = NewPolynomial(Deg, sec)
 		polysExp[i] = NewPolynomialExponent(polys[i])
 

--- a/pkg/math/polynomial/polynomial.go
+++ b/pkg/math/polynomial/polynomial.go
@@ -1,6 +1,8 @@
 package polynomial
 
 import (
+	"crypto/rand"
+
 	"github.com/taurusgroup/cmp-ecdsa/pkg/math/curve"
 	"github.com/taurusgroup/cmp-ecdsa/pkg/math/sample"
 )
@@ -22,7 +24,7 @@ func NewPolynomial(degree int, constant *curve.Scalar) *Polynomial {
 	polynomial.Coefficients[0] = *constant
 
 	for i := 1; i <= degree; i++ {
-		polynomial.Coefficients[i] = *sample.Scalar()
+		polynomial.Coefficients[i] = *sample.Scalar(rand.Reader)
 	}
 
 	return &polynomial

--- a/pkg/math/polynomial/polynomial_test.go
+++ b/pkg/math/polynomial/polynomial_test.go
@@ -1,8 +1,9 @@
 package polynomial
 
 import (
+	"crypto/rand"
 	"math/big"
-	"math/rand"
+	mrand "math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,7 +14,7 @@ import (
 
 func TestPolynomial_Constant(t *testing.T) {
 	deg := 10
-	secret := sample.Scalar()
+	secret := sample.Scalar(rand.Reader)
 	poly := NewPolynomial(deg, secret)
 	require.True(t, poly.Constant().Equal(secret))
 }
@@ -25,7 +26,7 @@ func TestPolynomial_Evaluate(t *testing.T) {
 	polynomial.Coefficients[2].SetUInt32(1)
 
 	for index := 0; index < 100; index++ {
-		x := rand.Uint32()
+		x := mrand.Uint32()
 		result := big.NewInt(int64(x))
 		result.Mul(result, result)
 		result.Add(result, big.NewInt(1))

--- a/pkg/math/sample/plus_minus.go
+++ b/pkg/math/sample/plus_minus.go
@@ -1,15 +1,16 @@
 package sample
 
 import (
+	"io"
 	"math/big"
 
 	"github.com/taurusgroup/cmp-ecdsa/pkg/params"
 )
 
-func sampleNeg(bits int) *big.Int {
+func sampleNeg(rand io.Reader, bits int) *big.Int {
 	var n big.Int
 	buf := make([]byte, bits/8+1)
-	mustReadBits(buf)
+	mustReadBits(rand, buf)
 	neg := buf[0]&1 == 1
 	buf = buf[1:]
 	n.SetBytes(buf)
@@ -20,31 +21,31 @@ func sampleNeg(bits int) *big.Int {
 }
 
 // IntervalL returns an integer in the range ± 2ˡ.
-func IntervalL() *big.Int {
-	return sampleNeg(params.L)
+func IntervalL(rand io.Reader) *big.Int {
+	return sampleNeg(rand, params.L)
 }
 
 // IntervalLPrime returns an integer in the range ± 2ˡº.
-func IntervalLPrime() *big.Int {
-	return sampleNeg(params.LPrime)
+func IntervalLPrime(rand io.Reader) *big.Int {
+	return sampleNeg(rand, params.LPrime)
 }
 
 // IntervalLEps returns an integer in the range ± 2ˡ⁺ᵉ
-func IntervalLEps() *big.Int {
-	return sampleNeg(params.LPlusEpsilon)
+func IntervalLEps(rand io.Reader) *big.Int {
+	return sampleNeg(rand, params.LPlusEpsilon)
 }
 
 // IntervalLPrimeEps returns an integer in the range ± 2ˡº⁺ᵉ
-func IntervalLPrimeEps() *big.Int {
-	return sampleNeg(params.LPrimePlusEpsilon)
+func IntervalLPrimeEps(rand io.Reader) *big.Int {
+	return sampleNeg(rand, params.LPrimePlusEpsilon)
 }
 
 // IntervalLN returns an integer in the range ± 2ˡ•N, where N is the size of a Paillier modulus.
-func IntervalLN() *big.Int {
-	return sampleNeg(params.L + params.BitsIntModN)
+func IntervalLN(rand io.Reader) *big.Int {
+	return sampleNeg(rand, params.L+params.BitsIntModN)
 }
 
 // IntervalLEpsN returns an integer in the range ± 2ˡ⁺ᵉ•N, where N is the size of a Paillier modulus.
-func IntervalLEpsN() *big.Int {
-	return sampleNeg(params.LPlusEpsilon + params.BitsIntModN)
+func IntervalLEpsN(rand io.Reader) *big.Int {
+	return sampleNeg(rand, params.LPlusEpsilon+params.BitsIntModN)
 }

--- a/pkg/math/sample/plus_minus.go
+++ b/pkg/math/sample/plus_minus.go
@@ -49,3 +49,8 @@ func IntervalLN(rand io.Reader) *big.Int {
 func IntervalLEpsN(rand io.Reader) *big.Int {
 	return sampleNeg(rand, params.LPlusEpsilon+params.BitsIntModN)
 }
+
+// IntervalScalar returns an integer in the range ±q, with q the size of a Scalar
+func IntervalScalar(rand io.Reader) *big.Int {
+	return sampleNeg(rand, params.BytesScalar*8)
+}

--- a/pkg/math/sample/sample.go
+++ b/pkg/math/sample/sample.go
@@ -1,7 +1,6 @@
 package sample
 
 import (
-	"crypto/rand"
 	"errors"
 	"fmt"
 	"io"
@@ -206,11 +205,11 @@ var ErrMaxPrimeIterations = fmt.Errorf("sample: failed to generate prime after %
 // This means that q := (p - 1) / 2 is also a prime number.
 //
 // This implies that p = 3 mod 4, otherwise q wouldn't be prime.
-func BlumPrime() *big.Int {
+func BlumPrime(rand io.Reader) *big.Int {
 	// TODO be more flexible on the number of bits in P, Q to avoid square root attack
 	one := new(big.Int).SetUint64(1)
 	for i := 0; i < maxPrimeIterations; i++ {
-		p, err := potentialSafePrime(rand.Reader, params.BitsBlumPrime)
+		p, err := potentialSafePrime(rand, params.BitsBlumPrime)
 		if err != nil {
 			continue
 		}
@@ -235,8 +234,8 @@ func BlumPrime() *big.Int {
 // Paillier generate the necessary integers for a Paillier key pair.
 // p, q are safe primes ((p - 1) / 2 is also prime), and Blum primes (p = 3 mod 4)
 // n = pq
-func Paillier() (p, q *big.Int) {
-	p, q = BlumPrime(), BlumPrime()
+func Paillier(rand io.Reader) (p, q *big.Int) {
+	p, q = BlumPrime(rand), BlumPrime(rand)
 	return
 }
 

--- a/pkg/math/sample/sample_test.go
+++ b/pkg/math/sample/sample_test.go
@@ -1,6 +1,7 @@
 package sample
 
 import (
+	"crypto/rand"
 	"math/big"
 	"testing"
 )
@@ -8,7 +9,7 @@ import (
 const blumPrimeProbabilityIterations = 20
 
 func TestBlumPrime(t *testing.T) {
-	p := BlumPrime()
+	p := BlumPrime(rand.Reader)
 	if !p.ProbablyPrime(blumPrimeProbabilityIterations) {
 		t.Error("BlumPrime generated a non prime number: ", p)
 	}
@@ -25,6 +26,6 @@ var resultBig *big.Int
 
 func BenchmarkBlumPrime(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		resultBig = BlumPrime()
+		resultBig = BlumPrime(rand.Reader)
 	}
 }

--- a/pkg/paillier/ciphertext.go
+++ b/pkg/paillier/ciphertext.go
@@ -1,6 +1,7 @@
 package paillier
 
 import (
+	"crypto/rand"
 	"io"
 	"math/big"
 	"math/bits"
@@ -50,7 +51,7 @@ func (ct Ciphertext) Clone() *Ciphertext {
 func (ct *Ciphertext) Randomize(pk *PublicKey, nonce *big.Int) *big.Int {
 	tmp := newCipherTextInt()
 	if nonce == nil {
-		nonce = sample.UnitModN(pk.N)
+		nonce = sample.UnitModN(rand.Reader, pk.N)
 	}
 	tmp.Exp(nonce, pk.N, pk.nSquared) // tmp = r^N
 	ct.C.Mul(ct.C, tmp)               // ct = ct * tmp

--- a/pkg/paillier/public.go
+++ b/pkg/paillier/public.go
@@ -1,6 +1,7 @@
 package paillier
 
 import (
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"io"
@@ -46,7 +47,7 @@ func NewPublicKey(n *big.Int) *PublicKey {
 //
 // ct = (1+N)ᵐρᴺ (mod N²)
 func (pk PublicKey) Enc(m *big.Int) (*Ciphertext, *big.Int) {
-	nonce := sample.UnitModN(pk.N)
+	nonce := sample.UnitModN(rand.Reader, pk.N)
 	return pk.EncWithNonce(m, nonce), nonce
 }
 

--- a/pkg/paillier/secret.go
+++ b/pkg/paillier/secret.go
@@ -37,7 +37,7 @@ func KeyGen() (pk *PublicKey, sk *SecretKey) {
 }
 
 func NewSecretKey() *SecretKey {
-	return NewSecretKeyFromPrimes(sample.Paillier())
+	return NewSecretKeyFromPrimes(sample.Paillier(rand.Reader))
 }
 
 func NewSecretKeyFromPrimes(P, Q *big.Int) *SecretKey {

--- a/pkg/paillier/secret.go
+++ b/pkg/paillier/secret.go
@@ -1,6 +1,7 @@
 package paillier
 
 import (
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"math/big"
@@ -103,7 +104,7 @@ func (sk *SecretKey) Clone() *SecretKey {
 
 func (sk SecretKey) GeneratePedersen() (ped *pedersen.Parameters, lambda *big.Int) {
 	var s, t *big.Int
-	s, t, lambda = sample.Pedersen(sk.PublicKey.N, sk.Phi)
+	s, t, lambda = sample.Pedersen(rand.Reader, sk.PublicKey.N, sk.Phi)
 	return &pedersen.Parameters{
 		N: sk.PublicKey.N,
 		S: s,

--- a/pkg/party/public_test.go
+++ b/pkg/party/public_test.go
@@ -21,7 +21,7 @@ func TestPublic_Validate(t *testing.T) {
 	N := p.N
 	ped, _ := sk.GeneratePedersen()
 
-	_, X := sample.ScalarPointPair()
+	_, X := sample.ScalarPointPair(rand.Reader)
 	N2 := big.NewInt(1)
 	N2.Add(N2, N)
 	p2 := paillier.NewPublicKey(N2)
@@ -140,7 +140,7 @@ func TestPublic_MarshalJSON(t *testing.T) {
 	ped, _ := sk.GeneratePedersen()
 	p := Public{
 		ID:       RandomIDs(1)[0],
-		ECDSA:    curve.NewIdentityPoint().ScalarBaseMult(sample.Scalar()),
+		ECDSA:    curve.NewIdentityPoint().ScalarBaseMult(sample.Scalar(rand.Reader)),
 		Paillier: pk,
 		Pedersen: ped,
 	}

--- a/pkg/party/secret_test.go
+++ b/pkg/party/secret_test.go
@@ -1,7 +1,7 @@
 package party
 
 import (
-	"math/rand"
+	"crypto/rand"
 	"testing"
 
 	"github.com/taurusgroup/cmp-ecdsa/pkg/math/curve"
@@ -16,7 +16,7 @@ func TestSecret_Validate(t *testing.T) {
 	_, _ = rand.Read(ssid)
 	_, _ = rand.Read(rid)
 
-	x, X := sample.ScalarPointPair()
+	x, X := sample.ScalarPointPair(rand.Reader)
 
 	sk := paillier.NewSecretKey()
 	pk := sk.PublicKey

--- a/pkg/session/fake.go
+++ b/pkg/session/fake.go
@@ -1,7 +1,7 @@
 package session
 
 import (
-	"math/rand"
+	"crypto/rand"
 
 	"github.com/taurusgroup/cmp-ecdsa/pkg/math/curve"
 	"github.com/taurusgroup/cmp-ecdsa/pkg/math/polynomial"
@@ -12,7 +12,7 @@ import (
 )
 
 func generateShares(parties party.IDSlice, t int) (shares []*curve.Scalar, sum *curve.Scalar) {
-	sum = sample.Scalar()
+	sum = sample.Scalar(rand.Reader)
 	f := polynomial.NewPolynomial(t, sum)
 
 	n := len(parties)

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -61,7 +61,7 @@ type Session interface {
 }
 
 func computeSSID(s Session) []byte {
-	ssid, _ := s.Hash().ReadBytes(nil)
+	ssid := s.Hash().ReadBytes(nil)
 	return ssid
 }
 

--- a/pkg/zk/affg/affg.go
+++ b/pkg/zk/affg/affg.go
@@ -1,6 +1,7 @@
 package zkaffg
 
 import (
+	"crypto/rand"
 	"math/big"
 
 	"github.com/taurusgroup/cmp-ecdsa/pkg/hash"
@@ -79,16 +80,16 @@ func NewProof(hash *hash.Hash, public Public, private Private) *Proof {
 	verifier := public.Verifier
 	prover := public.Prover
 
-	alpha := sample.IntervalLEps()
-	beta := sample.IntervalLPrimeEps()
+	alpha := sample.IntervalLEps(rand.Reader)
+	beta := sample.IntervalLPrimeEps(rand.Reader)
 
-	r := sample.UnitModN(N0)
-	rY := sample.UnitModN(N1)
+	r := sample.UnitModN(rand.Reader, N0)
+	rY := sample.UnitModN(rand.Reader, N1)
 
-	gamma := sample.IntervalLEpsN()
-	m := sample.IntervalLEpsN()
-	delta := sample.IntervalLEpsN()
-	mu := sample.IntervalLN()
+	gamma := sample.IntervalLEpsN(rand.Reader)
+	m := sample.IntervalLEpsN(rand.Reader)
+	delta := sample.IntervalLEpsN(rand.Reader)
+	mu := sample.IntervalLN(rand.Reader)
 
 	cAlpha := public.C.Clone().Mul(verifier, alpha)           // = Cᵃ mod N₀ = α ⊙ C
 	A := verifier.EncWithNonce(beta, r).Add(verifier, cAlpha) // = Enc₀(β,r) ⊕ (α ⊙ C)

--- a/pkg/zk/affg/affg.go
+++ b/pkg/zk/affg/affg.go
@@ -192,5 +192,5 @@ func challenge(hash *hash.Hash, public Public, commitment *Commitment) *big.Int 
 		commitment.A, commitment.Bx, commitment.By,
 		commitment.E, commitment.S, commitment.F, commitment.T)
 
-	return hash.ReadFqNegative()
+	return sample.IntervalScalar(hash)
 }

--- a/pkg/zk/affg/affg_test.go
+++ b/pkg/zk/affg/affg_test.go
@@ -1,6 +1,7 @@
 package zkaffg
 
 import (
+	"crypto/rand"
 	"math/big"
 	"testing"
 
@@ -20,10 +21,10 @@ func TestAffG(t *testing.T) {
 	c := big.NewInt(12)
 	C, _ := verifierPaillier.Enc(c)
 
-	x := sample.IntervalL()
+	x := sample.IntervalL(rand.Reader)
 	X := curve.NewIdentityPoint().ScalarBaseMult(curve.NewScalarBigInt(x))
 
-	y := sample.IntervalLPrime()
+	y := sample.IntervalLPrime(rand.Reader)
 	Y, rhoY := prover.Enc(y)
 
 	tmp := C.Clone().Mul(verifierPaillier, x)

--- a/pkg/zk/dec/dec.go
+++ b/pkg/zk/dec/dec.go
@@ -1,6 +1,7 @@
 package zkdec
 
 import (
+	"crypto/rand"
 	"math/big"
 
 	"github.com/taurusgroup/cmp-ecdsa/pkg/hash"
@@ -48,11 +49,11 @@ func (p Proof) IsValid(public Public) bool {
 func NewProof(hash *hash.Hash, public Public, private Private) *Proof {
 	N0 := public.Prover.N
 
-	alpha := sample.IntervalLEps()
+	alpha := sample.IntervalLEps(rand.Reader)
 
-	mu := sample.IntervalLN()
-	nu := sample.IntervalLEpsN()
-	r := sample.UnitModN(N0)
+	mu := sample.IntervalLN(rand.Reader)
+	nu := sample.IntervalLEpsN(rand.Reader)
+	r := sample.UnitModN(rand.Reader, N0)
 
 	gamma := curve.NewScalarBigInt(alpha)
 

--- a/pkg/zk/dec/dec.go
+++ b/pkg/zk/dec/dec.go
@@ -117,5 +117,5 @@ func challenge(hash *hash.Hash, public Public, commitment *Commitment) *big.Int 
 		public.C, public.X,
 		commitment.S, commitment.T, commitment.A, commitment.Gamma)
 
-	return hash.ReadFqNegative()
+	return sample.IntervalScalar(hash)
 }

--- a/pkg/zk/dec/dec_test.go
+++ b/pkg/zk/dec/dec_test.go
@@ -1,6 +1,7 @@
 package zkdec
 
 import (
+	"crypto/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,7 +16,7 @@ func TestDec(t *testing.T) {
 	verifierPedersen := zk.Pedersen
 	prover := zk.ProverPaillierPublic
 
-	y := sample.IntervalL()
+	y := sample.IntervalL(rand.Reader)
 	x := curve.NewScalarBigInt(y)
 
 	C, rho := prover.Enc(y)

--- a/pkg/zk/enc/enc.go
+++ b/pkg/zk/enc/enc.go
@@ -1,6 +1,7 @@
 package zkenc
 
 import (
+	"crypto/rand"
 	"math/big"
 
 	"github.com/taurusgroup/cmp-ecdsa/pkg/hash"
@@ -42,10 +43,10 @@ func (p Proof) IsValid(public Public) bool {
 func NewProof(hash *hash.Hash, public Public, private Private) *Proof {
 	N := public.Prover.N
 
-	alpha := sample.IntervalLEps()
-	r := sample.UnitModN(N)
-	mu := sample.IntervalLN()
-	gamma := sample.IntervalLEpsN()
+	alpha := sample.IntervalLEps(rand.Reader)
+	r := sample.UnitModN(rand.Reader, N)
+	mu := sample.IntervalLN(rand.Reader)
+	gamma := sample.IntervalLEpsN(rand.Reader)
 
 	A := public.Prover.EncWithNonce(alpha, r)
 

--- a/pkg/zk/enc/enc.go
+++ b/pkg/zk/enc/enc.go
@@ -102,5 +102,5 @@ func challenge(hash *hash.Hash, public Public, commitment *Commitment) *big.Int 
 	_, _ = hash.WriteAny(public.Aux, public.Prover, public.K,
 		commitment.S, commitment.A, commitment.C)
 
-	return hash.ReadFqNegative()
+	return sample.IntervalScalar(hash)
 }

--- a/pkg/zk/enc/enc_test.go
+++ b/pkg/zk/enc/enc_test.go
@@ -1,6 +1,7 @@
 package zkenc
 
 import (
+	"crypto/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,7 +15,7 @@ func TestEnc(t *testing.T) {
 	verifier := zk.Pedersen
 	prover := zk.ProverPaillierPublic
 
-	k := sample.IntervalL()
+	k := sample.IntervalL(rand.Reader)
 	K, rho := prover.Enc(k)
 	public := Public{
 		K:      K,

--- a/pkg/zk/logstar/logstar.go
+++ b/pkg/zk/logstar/logstar.go
@@ -135,5 +135,5 @@ func challenge(hash *hash.Hash, public Public, commitment *Commitment) *big.Int 
 	_, _ = hash.WriteAny(public.Aux, public.Prover, public.C, public.X, public.G,
 		commitment.S, commitment.A, commitment.Y, commitment.D)
 
-	return hash.ReadFqNegative()
+	return sample.IntervalScalar(hash)
 }

--- a/pkg/zk/logstar/logstar.go
+++ b/pkg/zk/logstar/logstar.go
@@ -1,6 +1,7 @@
 package zklogstar
 
 import (
+	"crypto/rand"
 	"math/big"
 
 	"github.com/taurusgroup/cmp-ecdsa/pkg/hash"
@@ -58,10 +59,10 @@ func NewProof(hash *hash.Hash, public Public, private Private) *Proof {
 		public.G = curve.NewBasePoint()
 	}
 
-	alpha := sample.IntervalLEps()
-	r := sample.UnitModN(N)
-	mu := sample.IntervalLN()
-	gamma := sample.IntervalLEpsN()
+	alpha := sample.IntervalLEps(rand.Reader)
+	r := sample.UnitModN(rand.Reader, N)
+	mu := sample.IntervalLN(rand.Reader)
+	gamma := sample.IntervalLEpsN(rand.Reader)
 
 	commitment := &Commitment{
 		A: public.Prover.EncWithNonce(alpha, r),

--- a/pkg/zk/logstar/logstar_test.go
+++ b/pkg/zk/logstar/logstar_test.go
@@ -1,6 +1,7 @@
 package zklogstar
 
 import (
+	"crypto/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,9 +16,9 @@ func TestLogStar(t *testing.T) {
 	verifier := zk.Pedersen
 	prover := zk.ProverPaillierPublic
 
-	G := curve.NewIdentityPoint().ScalarBaseMult(sample.Scalar())
+	G := curve.NewIdentityPoint().ScalarBaseMult(sample.Scalar(rand.Reader))
 
-	x := sample.IntervalL()
+	x := sample.IntervalL(rand.Reader)
 	C, rho := prover.Enc(x)
 	X := curve.NewIdentityPoint().ScalarMult(curve.NewScalarBigInt(x), G)
 	public := Public{

--- a/pkg/zk/mod/mod.go
+++ b/pkg/zk/mod/mod.go
@@ -218,16 +218,11 @@ func (p *Proof) Verify(hash *hash.Hash, public Public) bool {
 	return true
 }
 
-func challenge(h *hash.Hash, n, w *big.Int) []*big.Int {
-	_, _ = h.WriteAny(n, w)
-	intBuffer := make([]byte, params.BytesIntModN)
+func challenge(hash *hash.Hash, n, w *big.Int) []*big.Int {
+	_, _ = hash.WriteAny(n, w)
 	out := make([]*big.Int, params.StatParam)
 	for i := range out {
-		var r big.Int
-		_, _ = h.ReadBytes(intBuffer)
-		r.SetBytes(intBuffer)
-		r.Mod(&r, n)
-		out[i] = &r
+		out[i] = sample.ModN(hash, n)
 	}
 
 	return out

--- a/pkg/zk/mod/mod.go
+++ b/pkg/zk/mod/mod.go
@@ -1,6 +1,7 @@
 package zkmod
 
 import (
+	"crypto/rand"
 	"math/big"
 
 	"github.com/taurusgroup/cmp-ecdsa/pkg/hash"
@@ -126,7 +127,7 @@ func (p *Proof) IsValid(public Public) bool {
 //  - R = [(xᵢ aᵢ, bᵢ), zᵢ] for i = 1, …, m
 func NewProof(hash *hash.Hash, public Public, private Private) *Proof {
 	n, p, q, phi := public.N, private.P, private.Q, private.Phi
-	w := sample.QNR(n)
+	w := sample.QNR(rand.Reader, n)
 
 	nInverse := new(big.Int).ModInverse(n, phi)
 

--- a/pkg/zk/mod/mod_test.go
+++ b/pkg/zk/mod/mod_test.go
@@ -1,6 +1,7 @@
 package zkmod
 
 import (
+	"crypto/rand"
 	"math/big"
 	"testing"
 
@@ -48,7 +49,7 @@ func Test_set4thRoot(t *testing.T) {
 	n := big.NewInt(pInt * qInt)
 	phi := big.NewInt((pInt - 1) * (qInt - 1))
 	y := big.NewInt(502)
-	w := sample.QNR(n)
+	w := sample.QNR(rand.Reader, n)
 
 	a, b, x := makeQuadraticResidue(y, w, n, p, q)
 

--- a/pkg/zk/mul/mul.go
+++ b/pkg/zk/mul/mul.go
@@ -1,6 +1,7 @@
 package zkmul
 
 import (
+	"crypto/rand"
 	"math/big"
 
 	"github.com/taurusgroup/cmp-ecdsa/pkg/hash"
@@ -50,9 +51,9 @@ func NewProof(hash *hash.Hash, public Public, private Private) *Proof {
 
 	prover := public.Prover
 
-	alpha := sample.UnitModN(N)
-	r := sample.UnitModN(N)
-	s := sample.UnitModN(N)
+	alpha := sample.UnitModN(rand.Reader, N)
+	r := sample.UnitModN(rand.Reader, N)
+	s := sample.UnitModN(rand.Reader, N)
 
 	A := public.Y.Clone().Mul(prover, alpha)
 	A.Randomize(prover, r)

--- a/pkg/zk/mul/mul.go
+++ b/pkg/zk/mul/mul.go
@@ -112,5 +112,5 @@ func challenge(hash *hash.Hash, public Public, commitment *Commitment) *big.Int 
 	_, _ = hash.WriteAny(public.Prover,
 		public.X, public.Y, public.C,
 		commitment.A, commitment.B)
-	return hash.ReadFqNegative()
+	return sample.IntervalScalar(hash)
 }

--- a/pkg/zk/mul/mul_test.go
+++ b/pkg/zk/mul/mul_test.go
@@ -1,6 +1,7 @@
 package zkmul
 
 import (
+	"crypto/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,10 +13,10 @@ import (
 
 func TestMul(t *testing.T) {
 	prover := zk.ProverPaillierPublic
-	x := sample.IntervalL()
+	x := sample.IntervalL(rand.Reader)
 	X, rhoX := prover.Enc(x)
 
-	y := sample.IntervalL()
+	y := sample.IntervalL(rand.Reader)
 	Y, _ := prover.Enc(y)
 
 	C := Y.Clone().Mul(prover, x)

--- a/pkg/zk/mulstar/mulstar.go
+++ b/pkg/zk/mulstar/mulstar.go
@@ -133,5 +133,5 @@ func challenge(hash *hash.Hash, public Public, commitment *Commitment) *big.Int 
 		commitment.A, commitment.Bx,
 		commitment.E, commitment.S)
 
-	return hash.ReadFqNegative()
+	return sample.IntervalScalar(hash)
 }

--- a/pkg/zk/mulstar/mulstar.go
+++ b/pkg/zk/mulstar/mulstar.go
@@ -1,6 +1,7 @@
 package zkmulstar
 
 import (
+	"crypto/rand"
 	"math/big"
 
 	"github.com/taurusgroup/cmp-ecdsa/pkg/hash"
@@ -53,12 +54,12 @@ func NewProof(hash *hash.Hash, public Public, private Private) *Proof {
 
 	verifier := public.Verifier
 
-	alpha := sample.IntervalLEps()
+	alpha := sample.IntervalLEps(rand.Reader)
 
-	r := sample.UnitModN(N0)
+	r := sample.UnitModN(rand.Reader, N0)
 
-	gamma := sample.IntervalLEpsN()
-	m := sample.IntervalLEpsN()
+	gamma := sample.IntervalLEpsN(rand.Reader)
+	m := sample.IntervalLEpsN(rand.Reader)
 
 	A := public.C.Clone().Mul(verifier, alpha)
 	A.Randomize(verifier, r)

--- a/pkg/zk/mulstar/mulstar_test.go
+++ b/pkg/zk/mulstar/mulstar_test.go
@@ -1,6 +1,7 @@
 package zkmulstar
 
 import (
+	"crypto/rand"
 	"math/big"
 	"testing"
 
@@ -20,11 +21,11 @@ func TestMulG(t *testing.T) {
 	C, _ := verifierPaillier.Enc(c)
 
 	var X curve.Point
-	x := sample.IntervalL()
+	x := sample.IntervalL(rand.Reader)
 	X.ScalarBaseMult(curve.NewScalarBigInt(x))
 
 	D := C.Clone().Mul(verifierPaillier, x)
-	rho := sample.UnitModN(verifierPaillier.N)
+	rho := sample.UnitModN(rand.Reader, verifierPaillier.N)
 	D.Randomize(verifierPaillier, rho)
 
 	public := Public{

--- a/pkg/zk/prm/prm.go
+++ b/pkg/zk/prm/prm.go
@@ -114,8 +114,7 @@ func challenge(hash *hash.Hash, public Public, A []*big.Int) []bool {
 	}
 
 	tmpBytes := make([]byte, params.StatParam)
-
-	_, _ = hash.ReadBytes(tmpBytes)
+	hash.ReadBytes(tmpBytes)
 
 	out := make([]bool, params.StatParam)
 	for i := range out {

--- a/pkg/zk/prm/prm.go
+++ b/pkg/zk/prm/prm.go
@@ -1,6 +1,7 @@
 package zkprm
 
 import (
+	"crypto/rand"
 	"math/big"
 
 	"github.com/taurusgroup/cmp-ecdsa/pkg/hash"
@@ -43,7 +44,7 @@ func NewProof(hash *hash.Hash, public Public, private Private) *Proof {
 
 	for i := 0; i < params.StatParam; i++ {
 		// aᵢ ∈ mod ϕ(N)
-		a[i] = sample.IntervalLN()
+		a[i] = sample.IntervalLN(rand.Reader)
 		a[i].Mod(a[i], phi)
 
 		// Aᵢ = tᵃ mod N

--- a/pkg/zk/sch/sch.go
+++ b/pkg/zk/sch/sch.go
@@ -3,6 +3,7 @@ package zksch
 import (
 	"github.com/taurusgroup/cmp-ecdsa/pkg/hash"
 	"github.com/taurusgroup/cmp-ecdsa/pkg/math/curve"
+	"github.com/taurusgroup/cmp-ecdsa/pkg/math/sample"
 )
 
 type Commitment struct {
@@ -22,17 +23,17 @@ type Proof struct {
 
 func challenge(hash *hash.Hash, A, X *curve.Point) *curve.Scalar {
 	_, _ = hash.WriteAny(A, X)
-	return hash.ReadScalar()
+	return sample.Scalar(hash)
 }
 
-func challengeMult(h *hash.Hash, As, Xs []curve.Point) []*curve.Scalar {
+func challengeMult(hash *hash.Hash, As, Xs []curve.Point) []*curve.Scalar {
 	t := len(Xs)
 	for l := 0; l < t; l++ {
-		_, _ = h.WriteAny(&As[l], &Xs[l])
+		_, _ = hash.WriteAny(&As[l], &Xs[l])
 	}
 	es := make([]*curve.Scalar, t)
 	for l := range es {
-		es[l] = h.ReadScalar()
+		es[l] = sample.Scalar(hash)
 	}
 	return es
 }

--- a/pkg/zk/sch/sch_test.go
+++ b/pkg/zk/sch/sch_test.go
@@ -1,6 +1,7 @@
 package zksch
 
 import (
+	"crypto/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,15 +11,15 @@ import (
 )
 
 func TestSchPass(t *testing.T) {
-	x, X := sample.ScalarPointPair()
-	a, A := sample.ScalarPointPair()
+	x, X := sample.ScalarPointPair(rand.Reader)
+	a, A := sample.ScalarPointPair(rand.Reader)
 
 	proof := Prove(hash.New(), A, X, a, x)
 	assert.True(t, Verify(hash.New(), A, X, proof), "failed passing test")
 }
 func TestSchFail(t *testing.T) {
 	x, X := curve.NewScalar(), curve.NewIdentityPoint()
-	a, A := sample.ScalarPointPair()
+	a, A := sample.ScalarPointPair(rand.Reader)
 
 	proof := Prove(hash.New(), A, X, a, x)
 	assert.False(t, Verify(hash.New(), A, X, proof))

--- a/protocols/refresh/round1.go
+++ b/protocols/refresh/round1.go
@@ -72,7 +72,7 @@ func (r *round1) GenerateMessages() ([]round.Message, error) {
 	// if keygen then constant = secret, otherwise it is 0 (nil)
 	var constant *curve.Scalar
 	if r.isKeygen() {
-		constant = sample.Scalar()
+		constant = sample.Scalar(rand.Reader)
 	}
 	r.VSSSecret = polynomial.NewPolynomial(r.S.Threshold(), constant)
 
@@ -83,7 +83,7 @@ func (r *round1) GenerateMessages() ([]round.Message, error) {
 	r.Self.VSSPolynomial = polynomial.NewPolynomialExponent(r.VSSSecret)
 
 	// generate Schnorr randomness and commitments
-	r.SchnorrRand, r.Self.SchnorrCommitments = sample.ScalarPointPair()
+	r.SchnorrRand, r.Self.SchnorrCommitments = sample.ScalarPointPair(rand.Reader)
 
 	// Sample ρᵢ
 	r.Self.Rho = make([]byte, params.SecBytes)

--- a/protocols/refresh/round2.go
+++ b/protocols/refresh/round2.go
@@ -41,7 +41,7 @@ func (r *round2) GenerateMessages() ([]round.Message, error) {
 			return nil, fmt.Errorf("refresh.round2.GenerateMessages(): write commitments to hash: %w", err)
 		}
 	}
-	r.EchoHash, _ = h.ReadBytes(nil)
+	r.EchoHash = h.ReadBytes(nil)
 
 	return NewMessageRefresh2(r.SelfID, r.EchoHash), nil
 }

--- a/protocols/sign/mta.go
+++ b/protocols/sign/mta.go
@@ -1,6 +1,7 @@
 package sign
 
 import (
+	"crypto/rand"
 	"math/big"
 
 	"github.com/taurusgroup/cmp-ecdsa/pkg/hash"
@@ -53,7 +54,7 @@ func NewMtA(ai *curve.Scalar, Ai *curve.Point,
 	Kj *paillier.Ciphertext,
 	sender, receiver *party.Public) *MtA {
 
-	beta := sample.IntervalLPrime()
+	beta := sample.IntervalLPrime(rand.Reader)
 
 	betaNeg := new(big.Int).Neg(beta)
 	// Fⱼᵢ = encᵢ(-βᵢⱼ, rᵢⱼ)

--- a/protocols/sign/mta_test.go
+++ b/protocols/sign/mta_test.go
@@ -1,6 +1,7 @@
 package sign
 
 import (
+	"crypto/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,11 +23,11 @@ func Test_newMtA(t *testing.T) {
 	}
 	ski := zk.ProverPaillierSecret
 	skj := zk.VerifierPaillierSecret
-	ai, Ai := sample.ScalarPointPair()
-	aj, Aj := sample.ScalarPointPair()
+	ai, Ai := sample.ScalarPointPair(rand.Reader)
+	aj, Aj := sample.ScalarPointPair(rand.Reader)
 
-	bi := sample.Scalar()
-	bj := sample.Scalar()
+	bi := sample.Scalar(rand.Reader)
+	bj := sample.Scalar(rand.Reader)
 
 	Ki, _ := i.Paillier.Enc(bi.BigInt())
 	Kj, _ := j.Paillier.Enc(bj.BigInt())

--- a/protocols/sign/round1.go
+++ b/protocols/sign/round1.go
@@ -1,6 +1,7 @@
 package sign
 
 import (
+	"crypto/rand"
 	"math/big"
 
 	"github.com/taurusgroup/cmp-ecdsa/pkg/math/curve"
@@ -55,12 +56,12 @@ func (r *round1) ProcessMessage(round.Message) error {
 func (r *round1) GenerateMessages() ([]round.Message, error) {
 	// γᵢ <- 𝔽,
 	// Γᵢ = [γᵢ]⋅G
-	r.GammaShare, r.Self.BigGammaShare = sample.ScalarPointPair()
+	r.GammaShare, r.Self.BigGammaShare = sample.ScalarPointPair(rand.Reader)
 	// Gᵢ = Encᵢ(γᵢ;νᵢ)
 	r.Self.G, r.GNonce = r.Self.Paillier.Enc(r.GammaShare.BigInt())
 
 	// kᵢ <- 𝔽,
-	r.KShare = sample.Scalar()
+	r.KShare = sample.Scalar(rand.Reader)
 	// Kᵢ = Encᵢ(kᵢ;ρᵢ)
 	r.Self.K, r.KNonce = r.Self.Paillier.Enc(r.KShare.BigInt())
 

--- a/protocols/sign/round2.go
+++ b/protocols/sign/round2.go
@@ -93,7 +93,7 @@ func (r *round2) computeHashKJ() {
 		partyJ := r.parties[id]
 		_, _ = h.WriteAny(partyJ.K, partyJ.G)
 	}
-	r.EchoHash, _ = h.ReadBytes(nil)
+	r.EchoHash = h.ReadBytes(nil)
 	return
 }
 

--- a/protocols/sign/signature/signature_test.go
+++ b/protocols/sign/signature/signature_test.go
@@ -1,6 +1,7 @@
 package signature
 
 import (
+	"crypto/rand"
 	"testing"
 
 	"github.com/taurusgroup/cmp-ecdsa/pkg/math/curve"
@@ -9,7 +10,7 @@ import (
 
 func NewSignature(x *curve.Scalar, hash []byte, k *curve.Scalar) *Signature {
 	if k == nil {
-		k = sample.Scalar()
+		k = sample.Scalar(rand.Reader)
 	}
 	m := curve.NewScalar().SetHash(hash)
 	kInv := curve.NewScalar().Invert(k)
@@ -25,7 +26,7 @@ func NewSignature(x *curve.Scalar, hash []byte, k *curve.Scalar) *Signature {
 
 func TestSignature_Verify(t *testing.T) {
 	m := []byte("hello")
-	x := sample.Scalar()
+	x := sample.Scalar(rand.Reader)
 	X := curve.NewIdentityPoint().ScalarBaseMult(x)
 	sig := NewSignature(x, m, nil)
 	if !sig.Verify(X, m) {


### PR DESCRIPTION
Fixes #6.

This also allows us to use our Hash struct as input to these functions, removing the need for sampling functions inside of the hash package itself.

I've also taken the liberty of doing some minor cleanup in both of these packages.