### PR TITLE
Generate integers without modulo bias

### DIFF
--- a/pkg/math/sample/sample.go
+++ b/pkg/math/sample/sample.go
@@ -26,12 +26,13 @@ func mustReadBits(rand io.Reader, buf []byte) {
 // ModN samples an element of ℤₙ
 func ModN(rand io.Reader, n *big.Int) *big.Int {
 	out := new(big.Int)
+	buf := make([]byte, (n.BitLen()+7)/8)
 
-	buf := make([]byte, n.BitLen()/8)
-	mustReadBits(rand, buf)
-	// TODO: Make this sampling uniform
-	out.SetBytes(buf)
-	out.Mod(out, n)
+	for found := false; !found; found = out.Cmp(n) < 0 {
+		mustReadBits(rand, buf)
+		out.SetBytes(buf)
+		out.Mod(out, n)
+	}
 
 	return out
 }

--- a/pkg/math/sample/sample_test.go
+++ b/pkg/math/sample/sample_test.go
@@ -6,6 +6,17 @@ import (
 	"testing"
 )
 
+func TestModN(t *testing.T) {
+	n := new(big.Int).SetUint64(3 * 11 * 65519)
+	x := ModN(rand.Reader, n)
+	if x.Sign() < 0 {
+		t.Error("ModN generated a negative number: ", x)
+	}
+	if x.Cmp(n) >= 0 {
+		t.Errorf("ModN generated a number >= %v: %v", x, n)
+	}
+}
+
 const blumPrimeProbabilityIterations = 20
 
 func TestBlumPrime(t *testing.T) {

--- a/pkg/math/sample/sample_test.go
+++ b/pkg/math/sample/sample_test.go
@@ -4,6 +4,8 @@ import (
 	"crypto/rand"
 	"math/big"
 	"testing"
+
+	"github.com/taurusgroup/cmp-ecdsa/pkg/params"
 )
 
 func TestModN(t *testing.T) {
@@ -38,5 +40,16 @@ var resultBig *big.Int
 func BenchmarkBlumPrime(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		resultBig = BlumPrime(rand.Reader)
+	}
+}
+
+func BenchmarkModN(b *testing.B) {
+	b.StopTimer()
+	nBytes := make([]byte, (params.BitsPaillier+7)/8)
+	_, _ = rand.Read(nBytes)
+	n := new(big.Int).SetBytes(nBytes)
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		resultBig = ModN(rand.Reader, n)
 	}
 }


### PR DESCRIPTION
Fixes #5.

This uses rejection sampling to sample an integer mod N, instead of using the same number of bits, and then calling `.Mod`.

This isn't really any slower either.

I've also made these methods use the bit-length of the integer passed to the function, rather than a static security parameter. In practice, the integer passed to the function should have the same bit length as the security parameter. The idea is that checking that isn't really the responsibility of this function.

Now that #6 is closed, this was fixed in a central way. On the other hand, I'm not entirely sure if every single place where we generate an integer modulo N has been covered.