### PR TITLE
Adjust for typo in the proof PI(mod)

### DIFF
--- a/pkg/zk/mul/mul.go
+++ b/pkg/zk/mul/mul.go
@@ -51,7 +51,7 @@ func NewProof(hash *hash.Hash, public Public, private Private) *Proof {
 
 	prover := public.Prover
 
-	alpha := sample.UnitModN(rand.Reader, N)
+	alpha := sample.IntervalLEps(rand.Reader)
 	r := sample.UnitModN(rand.Reader, N)
 	s := sample.UnitModN(rand.Reader, N)
 

--- a/pkg/zk/mul/mul_test.go
+++ b/pkg/zk/mul/mul_test.go
@@ -41,6 +41,7 @@ func TestMul(t *testing.T) {
 	require.NoError(t, proof2.Unmarshal(out), "failed to unmarshal proof")
 	assert.Equal(t, proof, proof2)
 	out2, err := proof2.Marshal()
+	require.NoError(t, err, "failed to marshal proof")
 	assert.Equal(t, out, out2)
 	proof3 := &Proof{}
 	require.NoError(t, proof3.Unmarshal(out2), "failed to marshal 2nd proof")

--- a/threshold_protocol.md
+++ b/threshold_protocol.md
@@ -140,3 +140,26 @@ where $S$ is a subset of $\{ 1, \ldots, n \}$ of size at least $t+1$, and $m$ is
 
 The protocol goes exactly as before, except that the `Session` will use $S$ to determine Lagrange coefficients and apply them to the set of public keys, as well as the signer's secret share.
 Therefore, the resulting shares represent an additive sharing of the secret, and the original protocol can be used.
+
+## Paillier Multiplication proof $\Pi^{\text{mod}}$
+
+This is figure 28 in the CMP paper.
+
+Summarizing, they sample $\alpha, r, s \leftarrow \mathbb{Z}_N^*$. They then calculate:
+
+$$
+\begin{aligned}
+&Y^{\alpha} \cdot r^N\\
+&(1 + N)^{\alpha} s^N
+\end{aligned}
+$$
+
+Both $s$ and $r$ are used to multiply other values, so sampling from the
+unit group makes sense. On the other hand, $\alpha$ is used as an exponent,
+so this doesn't make sense. We believe that this is a typo, and that instead
+we should have:
+$$
+\alpha \leftarrow \pm 2^{l + \epsilon}
+$$
+
+This matches the generation of other exponents, such as in figure 29.


### PR DESCRIPTION
Fixes #10.

This documents our divergence from figure 28 in the CMP paper, in order to fix a typo in the paper.

This means sampling alpha from a uniform interval, instead of as a unit mod N, which makes sense, because alpha is used as an exponent.