### PR TITLE
Separate domains when hashing

### DIFF
--- a/internal/writer/domain.go
+++ b/internal/writer/domain.go
@@ -1,0 +1,39 @@
+package writer
+
+import "io"
+
+// WriterToWithDomain represents a type writing itself, and knowing its domain.
+//
+// Providing a domain string lets us distinguish the output of different types
+// implementing this same interface.
+type WriterToWithDomain interface {
+	io.WriterTo
+
+	// Domain returns a context string, which should be unique for each implementor
+	Domain() string
+}
+
+// WriteWithDomain writes out a piece of data, using its domain.
+func WriteWithDomain(w io.Writer, object WriterToWithDomain) (int64, error) {
+	total := int64(0)
+	// Write out `(<domain><data>)`, so that each domain separated piece of data
+	// is distinguished from others.
+	n, err := w.Write([]byte("("))
+	total += int64(n)
+	if err != nil {
+		return total, err
+	}
+	n, err = w.Write([]byte(object.Domain()))
+	total += int64(n)
+	if err != nil {
+		return total, err
+	}
+	n64, err := object.WriteTo(w)
+	total += n64
+	if err != nil {
+		return total, err
+	}
+	n, err = w.Write([]byte(")"))
+	total += int64(n)
+	return total, err
+}

--- a/internal/writer/domain.go
+++ b/internal/writer/domain.go
@@ -37,3 +37,23 @@ func WriteWithDomain(w io.Writer, object WriterToWithDomain) (int64, error) {
 	total += int64(n)
 	return total, err
 }
+
+// BytesWithDomain is a useful wrapper to annotate some chunk of data with a domain.
+//
+// The intention is to wrap some data using this struct, and then call WriteWithDomain,
+// or use this struct as a WriterToWithDomain somewhere else.
+type BytesWithDomain struct {
+	TheDomain string
+	Bytes     []byte
+}
+
+// WriteTo implements io.WriterTo
+func (b BytesWithDomain) WriteTo(w io.Writer) (int64, error) {
+	n, err := w.Write(b.Bytes)
+	return int64(n), err
+}
+
+// Domain implements WriterToWithDomain.
+func (b BytesWithDomain) Domain() string {
+	return b.TheDomain
+}

--- a/pkg/hash/commit.go
+++ b/pkg/hash/commit.go
@@ -41,7 +41,7 @@ func (Decommitment) Domain() string {
 // commitment = h(id, data, decommitment)
 func (hash *Hash) Commit(id party.ID, data ...interface{}) (Commitment, Decommitment, error) {
 	var err error
-	decommitment := make([]byte, params.SecBytes)
+	decommitment := Decommitment(make([]byte, params.SecBytes))
 
 	if _, err = rand.Read(decommitment); err != nil {
 		return nil, nil, fmt.Errorf("hash.Commit: failed to generate decommitment: %w", err)
@@ -55,7 +55,7 @@ func (hash *Hash) Commit(id party.ID, data ...interface{}) (Commitment, Decommit
 		}
 	}
 
-	_, _ = h.Write(decommitment)
+	_, _ = h.WriteAny(decommitment)
 
 	commitment := h.ReadBytes(nil)
 
@@ -78,7 +78,7 @@ func (hash *Hash) Decommit(id party.ID, c Commitment, d Decommitment, data ...in
 		}
 	}
 
-	_, _ = h.Write(d)
+	_, _ = h.WriteAny(d)
 
 	computedCommitment := h.ReadBytes(nil)
 

--- a/pkg/hash/commit.go
+++ b/pkg/hash/commit.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/rand"
 	"fmt"
+	"io"
 
 	"github.com/taurusgroup/cmp-ecdsa/pkg/params"
 	"github.com/taurusgroup/cmp-ecdsa/pkg/party"
@@ -13,6 +14,28 @@ type (
 	Commitment   []byte
 	Decommitment []byte
 )
+
+// WriteTo implements the io.WriterTo interface for Commitment.
+func (c Commitment) WriteTo(w io.Writer) (int64, error) {
+	n, err := w.Write(c)
+	return int64(n), err
+}
+
+// Domain implements WriterToWithDomain, and separates this type within hash.Hash.
+func (Commitment) Domain() string {
+	return "Commitment"
+}
+
+// WriteTo implements the io.WriterTo interface for Decommitment.
+func (d Decommitment) WriteTo(w io.Writer) (int64, error) {
+	n, err := w.Write(d)
+	return int64(n), err
+}
+
+// Domain implements WriterToWithDomain, and separates this type within hash.Hash.
+func (Decommitment) Domain() string {
+	return "Decommitment"
+}
 
 // Commit creates a commitment to data, and returns a commitment hash, and a decommitment string such that
 // commitment = h(id, data, decommitment)

--- a/pkg/hash/hash.go
+++ b/pkg/hash/hash.go
@@ -2,9 +2,9 @@ package hash
 
 import (
 	"fmt"
-	"io"
 	"math/big"
 
+	"github.com/taurusgroup/cmp-ecdsa/internal/writer"
 	"github.com/taurusgroup/cmp-ecdsa/pkg/params"
 	"github.com/taurusgroup/cmp-ecdsa/pkg/party"
 	"golang.org/x/crypto/sha3"
@@ -50,14 +50,6 @@ func (hash *Hash) ReadBytes(in []byte) []byte {
 		panic(fmt.Sprintf("hash.ReadBytes: internal hash failure: %v", err))
 	}
 	return in
-}
-
-// Write writes data to the hash state.
-//
-// Implements io.Writer
-func (hash *Hash) Write(data []byte) (int, error) {
-	// the underlying hash function never returns an error
-	return hash.h.Write(data)
 }
 
 // WriteAny takes many different data types and writes them to the hash state.
@@ -126,6 +118,6 @@ func (hash *Hash) Clone() *Hash {
 // CloneWithID returns a copy of the Hash in its current state, but also writes the ID to the new state.
 func (hash *Hash) CloneWithID(id party.ID) *Hash {
 	cloned := hash.Clone()
-	_, _ = cloned.Write([]byte(id))
+	_, _ = hash.WriteAny(id)
 	return cloned
 }

--- a/pkg/math/curve/point.go
+++ b/pkg/math/curve/point.go
@@ -182,10 +182,10 @@ func (v Point) WriteTo(w io.Writer) (int64, error) {
 	return int64(n), err
 }
 
-//
-//func (v *Point) HasEvenY() bool {
-//	return v.Y.Bit(0) == 0
-//}
+// Domain implements WriterToWithDomain, and separates this type within hash.Hash.
+func (Point) Domain() string {
+	return "Point"
+}
 
 // FromPublicKey returns a new Point from an ECDSA public key.
 // It assumes the point is correct, and if not the result is undefined

--- a/pkg/math/curve/scalar.go
+++ b/pkg/math/curve/scalar.go
@@ -158,3 +158,8 @@ func (s *Scalar) WriteTo(w io.Writer) (int64, error) {
 	n, err := w.Write(buf)
 	return int64(n), err
 }
+
+// Domain implements WriterToWithDomain, and separates this type within hash.Hash.
+func (*Scalar) Domain() string {
+	return "Scalar"
+}

--- a/pkg/math/polynomial/exponent.go
+++ b/pkg/math/polynomial/exponent.go
@@ -153,23 +153,33 @@ func (p *Exponent) Constant() *curve.Point {
 
 // WriteTo implements io.WriterTo and should be used within the hash.Hash function.
 func (p *Exponent) WriteTo(w io.Writer) (int64, error) {
-	// write the number of Coefficient
+	total := int64(0)
+
+	// write the number of Coefficients
 	_ = binary.Write(w, binary.BigEndian, uint32(p.Degree()))
-	nAll := int64(4)
 
 	if p.IsConstant {
 		// write only zeros
-		n0, _ := w.Write(make([]byte, params.BytesPoint))
-		nAll += int64(n0)
-	}
-
-	// write all Coefficient
-	for _, c := range p.Coefficients {
-		n, err := c.WriteTo(w)
-		nAll += n
+		n0, err := w.Write(make([]byte, params.BytesPoint))
+		total += int64(n0)
 		if err != nil {
-			return nAll, err
+			return total, err
 		}
 	}
-	return nAll, nil
+
+	// write all Coefficients
+	for _, c := range p.Coefficients {
+		n, err := c.WriteTo(w)
+		total += n
+		if err != nil {
+			return total, err
+		}
+	}
+
+	return total, nil
+}
+
+// Domain implements WriterToWithDomain, and separates this type within hash.Hash.
+func (*Exponent) Domain() string {
+	return "Exponent"
 }

--- a/pkg/paillier/ciphertext.go
+++ b/pkg/paillier/ciphertext.go
@@ -79,3 +79,8 @@ func (ct *Ciphertext) WriteTo(w io.Writer) (int64, error) {
 	n, err := w.Write(buf)
 	return int64(n), err
 }
+
+// Domain implements WriterToWithDomain, and separates this type within hash.Hash.
+func (*Ciphertext) Domain() string {
+	return "Paillier Ciphertext"
+}

--- a/pkg/paillier/public.go
+++ b/pkg/paillier/public.go
@@ -134,3 +134,8 @@ func (pk PublicKey) WriteTo(w io.Writer) (int64, error) {
 	n, err := w.Write(buf)
 	return int64(n), err
 }
+
+// Domain implements WriterToWithDomain, and separates this type within hash.Hash.
+func (PublicKey) Domain() string {
+	return "Paillier PublicKey"
+}

--- a/pkg/party/id.go
+++ b/pkg/party/id.go
@@ -1,13 +1,35 @@
 package party
 
-import "github.com/taurusgroup/cmp-ecdsa/pkg/math/curve"
+import (
+	"io"
 
+	"github.com/taurusgroup/cmp-ecdsa/pkg/math/curve"
+)
+
+// ID represents a private threshold share, used for signing.
+//
+// Internally we represent this using a string, so that we can sort IDs.
 type ID string
 
+// Scalar converts this ID into a scalar.
+//
+// All of the IDs of our participants form a polynomial sharing of the secret
+// scalar value used for ECDSA.
 func (id ID) Scalar() *curve.Scalar {
-	var s curve.Scalar
-	buffer := make([]byte, 32)
-	copy(buffer, id)
-	s.SetBytes(buffer)
-	return &s
+	out := new(curve.Scalar)
+	out.SetBytes([]byte(id))
+	return out
+}
+
+// WriteTo makes ID implement the io.WriterTo interface.
+//
+// This writes out the content of this ID, in a domain separated way.
+func (id ID) WriteTo(w io.Writer) (int64, error) {
+	n, err := w.Write([]byte(id))
+	return int64(n), err
+}
+
+// Domain implements WriterToWithDomain, and separates this type within hash.Hash.
+func (ID) Domain() string {
+	return "ID"
 }

--- a/pkg/party/idslice.go
+++ b/pkg/party/idslice.go
@@ -143,3 +143,8 @@ func (partyIDs IDSlice) WriteTo(w io.Writer) (int64, error) {
 
 	return nAll, nil
 }
+
+// Domain implements WriterToWithDomain, and separates this type within hash.Hash.
+func (IDSlice) Domain() string {
+	return "IDSlice"
+}

--- a/pkg/pedersen/pedersen.go
+++ b/pkg/pedersen/pedersen.go
@@ -123,3 +123,8 @@ func (p Parameters) WriteTo(w io.Writer) (int64, error) {
 	}
 	return nAll, nil
 }
+
+// Domain implements WriterToWithDomain, and separates this type within hash.Hash.
+func (Parameters) Domain() string {
+	return "Pedersen Parameters"
+}

--- a/pkg/session/keygen.go
+++ b/pkg/session/keygen.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 
 	"github.com/decred/dcrd/dcrec/secp256k1/v3"
+	"github.com/taurusgroup/cmp-ecdsa/internal/writer"
 	"github.com/taurusgroup/cmp-ecdsa/pkg/hash"
 	"github.com/taurusgroup/cmp-ecdsa/pkg/params"
 	"github.com/taurusgroup/cmp-ecdsa/pkg/party"
@@ -132,9 +133,21 @@ func (s Keygen) Hash() *hash.Hash {
 	h := hash.New()
 
 	// Write group information
-	_, _ = h.Write([]byte(s.group.Params().Name)) // 𝔾
-	_, _ = h.Write(s.group.Params().N.Bytes())    // q
-	_, _ = h.Write(s.group.Params().Gx.Bytes())   // Gₓ
+	// 𝔾
+	_, _ = h.WriteAny(&writer.BytesWithDomain{
+		TheDomain: "Group Name",
+		Bytes:     []byte(s.group.Params().Name),
+	})
+	// q
+	_, _ = h.WriteAny(&writer.BytesWithDomain{
+		TheDomain: "Group Order",
+		Bytes:     s.group.Params().N.Bytes(),
+	})
+	// Gₓ
+	_, _ = h.WriteAny(&writer.BytesWithDomain{
+		TheDomain: "Generator X Coordinate",
+		Bytes:     s.group.Params().Gx.Bytes(),
+	})
 
 	// write t
 	binary.BigEndian.PutUint64(intBuffer, uint64(s.threshold))

--- a/pkg/session/refresh.go
+++ b/pkg/session/refresh.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 
+	"github.com/taurusgroup/cmp-ecdsa/internal/writer"
 	"github.com/taurusgroup/cmp-ecdsa/pkg/hash"
 	"github.com/taurusgroup/cmp-ecdsa/pkg/math/curve"
 	"github.com/taurusgroup/cmp-ecdsa/pkg/params"
@@ -127,7 +128,10 @@ func (s Refresh) Hash() *hash.Hash {
 	h := s.Keygen.Hash()
 
 	// RID (since secret is already set)
-	_, _ = h.Write(s.rid)
+	_, _ = h.WriteAny(&writer.BytesWithDomain{
+		TheDomain: "RID",
+		Bytes:     s.rid,
+	})
 
 	// write all public info from parties in order
 	for _, partyID := range s.PartyIDs() {

--- a/pkg/session/sign.go
+++ b/pkg/session/sign.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/taurusgroup/cmp-ecdsa/internal/writer"
 	"github.com/taurusgroup/cmp-ecdsa/pkg/hash"
 	"github.com/taurusgroup/cmp-ecdsa/pkg/math/curve"
 	"github.com/taurusgroup/cmp-ecdsa/pkg/party"
@@ -115,7 +116,10 @@ func (s Sign) Hash() *hash.Hash {
 	_, _ = h.WriteAny(s.signerIDs)
 
 	// write Message
-	_, _ = h.Write(s.message)
+	_, _ = h.WriteAny(&writer.BytesWithDomain{
+		TheDomain: "Message",
+		Bytes:     s.message,
+	})
 
 	return h
 }

--- a/protocols/refresh/round2.go
+++ b/protocols/refresh/round2.go
@@ -36,7 +36,7 @@ func (r *round2) GenerateMessages() ([]round.Message, error) {
 	// Broadcast the message we created in round1
 	h := r.Hash.Clone()
 	for _, partyID := range r.S.PartyIDs() {
-		_, err = h.Write(r.LocalParties[partyID].Commitment)
+		_, err = h.WriteAny(r.LocalParties[partyID].Commitment)
 		if err != nil {
 			return nil, fmt.Errorf("refresh.round2.GenerateMessages(): write commitments to hash: %w", err)
 		}

--- a/protocols/refresh/round4.go
+++ b/protocols/refresh/round4.go
@@ -3,6 +3,7 @@ package refresh
 import (
 	"fmt"
 
+	"github.com/taurusgroup/cmp-ecdsa/internal/writer"
 	"github.com/taurusgroup/cmp-ecdsa/pkg/paillier"
 	"github.com/taurusgroup/cmp-ecdsa/pkg/params"
 	"github.com/taurusgroup/cmp-ecdsa/pkg/round"
@@ -93,7 +94,10 @@ func (r *round4) GenerateMessages() ([]round.Message, error) {
 	}
 
 	// Write Rho to the hash state
-	_, _ = r.Hash.Write(r.rho)
+	_, _ = r.Hash.WriteAny(&writer.BytesWithDomain{
+		TheDomain: "Rho",
+		Bytes:     r.rho,
+	})
 
 	// Prove N is a blum prime with zkmod
 	mod := zkmod.NewProof(r.Hash.CloneWithID(r.SelfID), zkmod.Public{N: r.Self.Public.Pedersen.N}, zkmod.Private{

--- a/protocols/refresh/round5.go
+++ b/protocols/refresh/round5.go
@@ -3,6 +3,7 @@ package refresh
 import (
 	"fmt"
 
+	"github.com/taurusgroup/cmp-ecdsa/internal/writer"
 	"github.com/taurusgroup/cmp-ecdsa/pkg/math/curve"
 	"github.com/taurusgroup/cmp-ecdsa/pkg/math/polynomial"
 	"github.com/taurusgroup/cmp-ecdsa/pkg/party"
@@ -125,7 +126,10 @@ func (r *round5) GenerateMessages() ([]round.Message, error) {
 	if err != nil {
 		return nil, fmt.Errorf("refresh.round5.GenerateMessages(): compute SSID: %w", err)
 	}
-	_, _ = r.Hash.Write(r.newSession.SSID())
+	_, _ = r.Hash.WriteAny(&writer.BytesWithDomain{
+		TheDomain: "SSID",
+		Bytes:     r.newSession.SSID(),
+	})
 
 	proof := zksch.Prove(r.Hash.CloneWithID(r.SelfID),
 		r.Self.SchnorrCommitments,


### PR DESCRIPTION
Fixes #9.

We hash a lot of different types of things, usually to commit to their value. We hash Scalars, Curve Points, IDs, and plain old byte slices. In theory, you could have an issue because you can't distinguish between say, a Curve Point, and two field elements. To resolve this, you can make sure that each type of thing you hash is surrounded by a different context. For example, instead of hashing a Curve point with bytes `<bytes>` you'd instead hash the byte string:

```
(Curve Point<bytes>)
```

This distinguishes these bytes from a generic byte slice, or from two field elements. The opening and closing parentheses also avoid issues where the bytes of one object contain the domain string of another object.

The tricky thing is making sure that this scheme is globally enforced.

To create an enforcement bottleneck, this patch only allows you to write into a Hash through a single method: `Hash.WriteAny`. Since everything goes through this method, we can make sure that domain separation happens.

This patch creates a new interface, analogous to `io.WriterTo`, that also contains a domain string. By using this string, our generic hash function can separate different types implementing this interface. For concrete types, it falls back on a straightforward domain string like `[]byte`.

Finally, many one-off byte slices are wrapped with an appropriate domain string, to differentiate them from each other. For example, the bytes of the name of a curve are differentiated from the bytes of that curve's order.