### PR TITLE
Bug: CMP Key Generation stalls at round 4

### DIFF
--- a/internal/hash/commit.go
+++ b/internal/hash/commit.go
@@ -70,7 +70,7 @@ func (hash *Hash) Commit(data ...interface{}) (Commitment, Decommitment, error) 
 
 	_, _ = h.WriteAny(decommitment)
 
-	commitment := h.ReadBytes(nil)
+	commitment := h.DefaultDigest(nil)
 
 	return commitment, decommitment, nil
 }
@@ -96,7 +96,7 @@ func (hash *Hash) Decommit(c Commitment, d Decommitment, data ...interface{}) bo
 
 	_, _ = h.WriteAny(d)
 
-	computedCommitment := h.ReadBytes(nil)
+	computedCommitment := h.DefaultDigest(nil)
 
 	return bytes.Equal(computedCommitment, c)
 }

--- a/internal/hash/commit.go
+++ b/internal/hash/commit.go
@@ -26,8 +26,8 @@ func (Commitment) Domain() string {
 }
 
 func (c Commitment) Validate() error {
-	if l := len(c); l != params.HashBytes {
-		return fmt.Errorf("commitment: incorrect length (got %d, expected %d)", l, params.HashBytes)
+	if l := len(c); l != DigestLengthBytes {
+		return fmt.Errorf("commitment: incorrect length (got %d, expected %d)", l, DigestLengthBytes)
 	}
 	return nil
 }
@@ -70,7 +70,7 @@ func (hash *Hash) Commit(data ...interface{}) (Commitment, Decommitment, error) 
 
 	_, _ = h.WriteAny(decommitment)
 
-	commitment := h.DefaultDigest(nil)
+	commitment := h.Sum()
 
 	return commitment, decommitment, nil
 }
@@ -96,7 +96,7 @@ func (hash *Hash) Decommit(c Commitment, d Decommitment, data ...interface{}) bo
 
 	_, _ = h.WriteAny(d)
 
-	computedCommitment := h.DefaultDigest(nil)
+	computedCommitment := h.Sum()
 
 	return bytes.Equal(computedCommitment, c)
 }

--- a/internal/params/params.go
+++ b/internal/params/params.go
@@ -4,8 +4,7 @@ import "github.com/decred/dcrd/dcrec/secp256k1/v3"
 
 const (
 	SecParam  = 256
-	HashBytes = 64
-	SecBytes  = 32
+	SecBytes  = SecParam / 8
 	StatParam = 80
 
 	// ZKModIterations is the number of iterations that are performed to prove the validity of

--- a/internal/round/helper.go
+++ b/internal/round/helper.go
@@ -63,7 +63,7 @@ func NewHelper(protocolID types.ProtocolID, finalRoundNumber types.RoundNumber,
 		partyIDs:         partyIDs,
 		otherPartyIDs:    partyIDs.Remove(selfID),
 		group:            group,
-		ssid:             h.Clone().ReadBytes(nil),
+		ssid:             h.Clone().DefaultDigest(nil),
 		hash:             h,
 	}, nil
 }

--- a/internal/round/helper.go
+++ b/internal/round/helper.go
@@ -63,7 +63,7 @@ func NewHelper(protocolID types.ProtocolID, finalRoundNumber types.RoundNumber,
 		partyIDs:         partyIDs,
 		otherPartyIDs:    partyIDs.Remove(selfID),
 		group:            group,
-		ssid:             h.Clone().DefaultDigest(nil),
+		ssid:             h.Clone().Sum(),
 		hash:             h,
 	}, nil
 }

--- a/pkg/zk/affg/affg.go
+++ b/pkg/zk/affg/affg.go
@@ -217,5 +217,5 @@ func challenge(hash *hash.Hash, public Public, commitment *Commitment) *safenum.
 		commitment.A, commitment.Bx, commitment.By,
 		commitment.E, commitment.S, commitment.F, commitment.T)
 
-	return sample.IntervalScalar(hash)
+	return sample.IntervalScalar(hash.Digest())
 }

--- a/pkg/zk/dec/dec.go
+++ b/pkg/zk/dec/dec.go
@@ -130,5 +130,5 @@ func challenge(hash *hash.Hash, public Public, commitment *Commitment) *safenum.
 		public.C, public.X,
 		commitment.S, commitment.T, commitment.A, commitment.Gamma)
 
-	return sample.IntervalScalar(hash)
+	return sample.IntervalScalar(hash.Digest())
 }

--- a/pkg/zk/enc/enc.go
+++ b/pkg/zk/enc/enc.go
@@ -114,5 +114,5 @@ func challenge(hash *hash.Hash, public Public, commitment *Commitment) *safenum.
 	_, _ = hash.WriteAny(public.Aux, public.Prover, public.K,
 		commitment.S, commitment.A, commitment.C)
 
-	return sample.IntervalScalar(hash)
+	return sample.IntervalScalar(hash.Digest())
 }

--- a/pkg/zk/logstar/logstar.go
+++ b/pkg/zk/logstar/logstar.go
@@ -148,5 +148,5 @@ func challenge(hash *hash.Hash, public Public, commitment *Commitment) *safenum.
 	_, _ = hash.WriteAny(public.Aux, public.Prover, public.C, public.X, public.G,
 		commitment.S, commitment.A, commitment.Y, commitment.D)
 
-	return sample.IntervalScalar(hash)
+	return sample.IntervalScalar(hash.Digest())
 }

--- a/pkg/zk/mod/mod.go
+++ b/pkg/zk/mod/mod.go
@@ -251,7 +251,7 @@ func challenge(hash *hash.Hash, n, w *big.Int) []*big.Int {
 	out := make([]*big.Int, params.StatParam)
 	nMod := safenum.ModulusFromNat(new(safenum.Nat).SetBig(n, n.BitLen()))
 	for i := range out {
-		out[i] = sample.ModN(hash, nMod).Big()
+		out[i] = sample.ModN(hash.Digest(), nMod).Big()
 	}
 
 	return out

--- a/pkg/zk/mul/mul.go
+++ b/pkg/zk/mul/mul.go
@@ -125,5 +125,5 @@ func challenge(hash *hash.Hash, public Public, commitment *Commitment) *safenum.
 	_, _ = hash.WriteAny(public.Prover,
 		public.X, public.Y, public.C,
 		commitment.A, commitment.B)
-	return sample.IntervalScalar(hash)
+	return sample.IntervalScalar(hash.Digest())
 }

--- a/pkg/zk/mulstar/mulstar.go
+++ b/pkg/zk/mulstar/mulstar.go
@@ -145,5 +145,5 @@ func challenge(hash *hash.Hash, public Public, commitment *Commitment) *safenum.
 		commitment.A, commitment.Bx,
 		commitment.E, commitment.S)
 
-	return sample.IntervalScalar(hash)
+	return sample.IntervalScalar(hash.Digest())
 }

--- a/pkg/zk/prm/prm.go
+++ b/pkg/zk/prm/prm.go
@@ -2,6 +2,7 @@ package zkprm
 
 import (
 	"crypto/rand"
+	"io"
 	"math/big"
 
 	"github.com/cronokirby/safenum"
@@ -117,7 +118,7 @@ func challenge(hash *hash.Hash, public Public, A []*big.Int) []bool {
 	}
 
 	tmpBytes := make([]byte, params.StatParam)
-	hash.ReadBytes(tmpBytes)
+	_, _ = io.ReadFull(hash.Digest(), tmpBytes)
 
 	out := make([]bool, params.StatParam)
 	for i := range out {

--- a/pkg/zk/sch/sch.go
+++ b/pkg/zk/sch/sch.go
@@ -36,7 +36,7 @@ func NewRandomness(rand io.Reader) *Randomness {
 
 func challenge(hash *hash.Hash, commitment *Commitment, public *curve.Point) *curve.Scalar {
 	_, _ = hash.WriteAny(&commitment.C, public)
-	return sample.Scalar(hash)
+	return sample.Scalar(hash.Digest())
 }
 
 // Prove creates a Response = Randomness + H(..., Commitment, public)•secret (mod p).

--- a/protocols/cmp/keygen/round2.go
+++ b/protocols/cmp/keygen/round2.go
@@ -77,7 +77,7 @@ func (r *round2) Finalize(out chan<- *message.Message) (round.Round, error) {
 	for _, j := range r.PartyIDs() {
 		_, _ = h.WriteAny(r.Commitments[j])
 	}
-	EchoHash := h.ReadBytes(nil)
+	EchoHash := h.DefaultDigest(nil)
 
 	// send to all
 	msg := r.MarshalMessage(&Keygen3{HashEcho: EchoHash}, r.OtherPartyIDs()...)

--- a/protocols/cmp/keygen/round2.go
+++ b/protocols/cmp/keygen/round2.go
@@ -77,7 +77,7 @@ func (r *round2) Finalize(out chan<- *message.Message) (round.Round, error) {
 	for _, j := range r.PartyIDs() {
 		_, _ = h.WriteAny(r.Commitments[j])
 	}
-	EchoHash := h.DefaultDigest(nil)
+	EchoHash := h.Sum()
 
 	// send to all
 	msg := r.MarshalMessage(&Keygen3{HashEcho: EchoHash}, r.OtherPartyIDs()...)

--- a/protocols/cmp/keygen/round3.go
+++ b/protocols/cmp/keygen/round3.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/taurusgroup/cmp-ecdsa/internal/params"
+	"github.com/taurusgroup/cmp-ecdsa/internal/hash"
 	"github.com/taurusgroup/cmp-ecdsa/internal/round"
 	"github.com/taurusgroup/cmp-ecdsa/pkg/party"
 	"github.com/taurusgroup/cmp-ecdsa/pkg/protocol/message"
@@ -61,8 +61,8 @@ func (m *Keygen3) Validate() error {
 	if m == nil {
 		return errors.New("keygen.round2: message is nil")
 	}
-	if l := len(m.HashEcho); l != params.HashBytes {
-		return fmt.Errorf("keygen.round2: invalid echo hash length (got %d, expected %d)", l, params.HashBytes)
+	if l := len(m.HashEcho); l != hash.DigestLengthBytes {
+		return fmt.Errorf("keygen.round2: invalid echo hash length (got %d, expected %d)", l, hash.DigestLengthBytes)
 	}
 	return nil
 }

--- a/protocols/cmp/sign/round2.go
+++ b/protocols/cmp/sign/round2.go
@@ -73,7 +73,7 @@ func (r *round2) Finalize(out chan<- *message.Message) (round.Round, error) {
 	for _, j := range r.PartyIDs() {
 		_, _ = h.WriteAny(r.K[j], r.G[j])
 	}
-	EchoHash := h.DefaultDigest(nil)
+	EchoHash := h.Sum()
 
 	zkPrivate := zklogstar.Private{
 		X:   r.GammaShare.Int(),

--- a/protocols/cmp/sign/round2.go
+++ b/protocols/cmp/sign/round2.go
@@ -73,7 +73,7 @@ func (r *round2) Finalize(out chan<- *message.Message) (round.Round, error) {
 	for _, j := range r.PartyIDs() {
 		_, _ = h.WriteAny(r.K[j], r.G[j])
 	}
-	EchoHash := h.ReadBytes(nil)
+	EchoHash := h.DefaultDigest(nil)
 
 	zkPrivate := zklogstar.Private{
 		X:   r.GammaShare.Int(),

--- a/protocols/frost/sign/round2.go
+++ b/protocols/frost/sign/round2.go
@@ -90,7 +90,7 @@ func (r *round2) Finalize(out chan<- *message.Message) (round.Round, error) {
 	for _, l := range r.PartyIDs() {
 		rhoHash := rhoPreHash.Clone()
 		_, _ = rhoHash.WriteAny(l)
-		rho[l] = sample.Scalar(rhoHash)
+		rho[l] = sample.Scalar(rhoHash.Digest())
 	}
 
 	R := curve.NewIdentityPoint()
@@ -124,7 +124,7 @@ func (r *round2) Finalize(out chan<- *message.Message) (round.Round, error) {
 	} else {
 		cHash := hash.New()
 		_, _ = cHash.WriteAny(R, r.Y, r.M)
-		c = sample.Scalar(cHash)
+		c = sample.Scalar(cHash.Digest())
 	}
 
 	// Lambdas[i] = λᵢ

--- a/protocols/frost/sign/types.go
+++ b/protocols/frost/sign/types.go
@@ -42,7 +42,7 @@ type Signature struct {
 func (sig Signature) Verify(public *curve.Point, m []byte) bool {
 	challengeHash := hash.New()
 	_, _ = challengeHash.WriteAny(sig.R, public, messageHash(m))
-	challenge := sample.Scalar(challengeHash)
+	challenge := sample.Scalar(challengeHash.Digest())
 
 	expected := curve.NewIdentityPoint().ScalarMult(challenge, public)
 	expected.Add(expected, sig.R)


### PR DESCRIPTION
Fixes #44

This was actually a regression introduced when we started using BLAKE3.
Previously, our Read method for Hash would modify the state of the hash,
so multiple subsequent calls would result in different values.

With BLAKE3, we were calling .Digest().Read() each time, which finalized
the current state of the hash, and then read some bytes from that
digest. The problem is that each new call to Read calls Digest() from
the same state, thus producing the same output.

This lead to a spurious deadlock in methods that use rejection sampling, since
if you were unlucky in your sampling, you would always get stuck, since
you would never read different data.

This was spurious, because you need to be unlucky for this to happen.

The fix is to explicitly require calling .Digest() on Hash, in order to
get an io.Reader, instead of having Hash implement io.Reader itself.
This means that there's a clear point where you start reading the output
of what you've hashed so far.