### PR TITLE
Move writer.WriterToWithDomain to hash, and simplify the interface.

### DIFF
--- a/internal/hash/commit.go
+++ b/internal/hash/commit.go
@@ -63,12 +63,12 @@ func (hash *Hash) Commit(data ...interface{}) (Commitment, Decommitment, error) 
 	h := hash.Clone()
 
 	for _, item := range data {
-		if _, err = h.WriteAny(item); err != nil {
+		if err = h.WriteAny(item); err != nil {
 			return nil, nil, fmt.Errorf("hash.Commit: failed to write data: %w", err)
 		}
 	}
 
-	_, _ = h.WriteAny(decommitment)
+	_ = h.WriteAny(decommitment)
 
 	commitment := h.Sum()
 
@@ -89,12 +89,12 @@ func (hash *Hash) Decommit(c Commitment, d Decommitment, data ...interface{}) bo
 	h := hash.Clone()
 
 	for _, item := range data {
-		if _, err = h.WriteAny(item); err != nil {
+		if err = h.WriteAny(item); err != nil {
 			return false
 		}
 	}
 
-	_, _ = h.WriteAny(d)
+	_ = h.WriteAny(d)
 
 	computedCommitment := h.Sum()
 

--- a/internal/hash/hash.go
+++ b/internal/hash/hash.go
@@ -79,8 +79,11 @@ func (hash *Hash) WriteAny(data ...interface{}) error {
 		// is distinguished from others.
 		_, _ = hash.h.WriteString("(")
 		_, _ = hash.h.WriteString(toBeWritten.Domain())
-		_, _ = toBeWritten.WriteTo(hash.h)
+		_, err := toBeWritten.WriteTo(hash.h)
 		_, _ = hash.h.WriteString(")")
+		if err != nil {
+			return fmt.Errorf("hash.WriteAny: %w", err)
+		}
 	}
 	return nil
 }

--- a/internal/hash/hash_test.go
+++ b/internal/hash/hash_test.go
@@ -14,7 +14,7 @@ func TestHash_WriteAny(t *testing.T) {
 
 	a := func(v interface{}) {
 		h := New()
-		_, err = h.WriteAny(v)
+		err = h.WriteAny(v)
 		if err != nil {
 			t.Error(err)
 		}
@@ -22,7 +22,7 @@ func TestHash_WriteAny(t *testing.T) {
 	b := func(vs ...interface{}) {
 		h := New()
 		for _, v := range vs {
-			_, err = h.WriteAny(v)
+			err = h.WriteAny(v)
 			if err != nil {
 				t.Error(err)
 			}

--- a/internal/hash/writerto.go
+++ b/internal/hash/writerto.go
@@ -13,25 +13,6 @@ type WriterToWithDomain interface {
 	Domain() string
 }
 
-// writeWithDomain writes out a piece of data, using its domain.
-func writeWithDomain(w io.Writer, object WriterToWithDomain) error {
-	// Write out `(<domain><data>)`, so that each domain separated piece of data
-	// is distinguished from others.
-	if _, err := w.Write([]byte("(")); err != nil {
-		return err
-	}
-	if _, err := w.Write([]byte(object.Domain())); err != nil {
-		return err
-	}
-	if _, err := object.WriteTo(w); err != nil {
-		return err
-	}
-	if _, err := w.Write([]byte(")")); err != nil {
-		return err
-	}
-	return nil
-}
-
 // BytesWithDomain is a useful wrapper to annotate some chunk of data with a domain.
 //
 // The intention is to wrap some data using this struct, and then call WriteWithDomain,

--- a/internal/hash/writerto.go
+++ b/internal/hash/writerto.go
@@ -1,4 +1,4 @@
-package writer
+package hash
 
 import "io"
 
@@ -13,29 +13,23 @@ type WriterToWithDomain interface {
 	Domain() string
 }
 
-// WriteWithDomain writes out a piece of data, using its domain.
-func WriteWithDomain(w io.Writer, object WriterToWithDomain) (int64, error) {
-	total := int64(0)
+// writeWithDomain writes out a piece of data, using its domain.
+func writeWithDomain(w io.Writer, object WriterToWithDomain) error {
 	// Write out `(<domain><data>)`, so that each domain separated piece of data
 	// is distinguished from others.
-	n, err := w.Write([]byte("("))
-	total += int64(n)
-	if err != nil {
-		return total, err
+	if _, err := w.Write([]byte("(")); err != nil {
+		return err
 	}
-	n, err = w.Write([]byte(object.Domain()))
-	total += int64(n)
-	if err != nil {
-		return total, err
+	if _, err := w.Write([]byte(object.Domain())); err != nil {
+		return err
 	}
-	n64, err := object.WriteTo(w)
-	total += n64
-	if err != nil {
-		return total, err
+	if _, err := object.WriteTo(w); err != nil {
+		return err
 	}
-	n, err = w.Write([]byte(")"))
-	total += int64(n)
-	return total, err
+	if _, err := w.Write([]byte(")")); err != nil {
+		return err
+	}
+	return nil
 }
 
 // BytesWithDomain is a useful wrapper to annotate some chunk of data with a domain.

--- a/internal/round/helper.go
+++ b/internal/round/helper.go
@@ -73,12 +73,8 @@ func NewHelper(protocolID types.ProtocolID, finalRoundNumber types.RoundNumber,
 // It computes
 // - Hash(𝔾, q, Gₓ, n, P₁, …, Pₙ, auxInfo}.
 func hashFromSID(protocolID types.ProtocolID, group elliptic.Curve, partyIDs party.IDSlice, auxInfo ...hash.WriterToWithDomain) *hash.Hash {
-	h := hash.New()
-
-	// Write SID
-	// protocolID 𝔾, q, Gₓ, n, P₁, …, Pₙ
-	_ = h.WriteAny(
-		protocolID,
+	// sid = protocolID 𝔾, q, Gₓ, n, P₁, …, Pₙ
+	sid := []hash.WriterToWithDomain{
 		&hash.BytesWithDomain{
 			TheDomain: "Group Name",
 			Bytes:     []byte(group.Params().Name),
@@ -92,11 +88,8 @@ func hashFromSID(protocolID types.ProtocolID, group elliptic.Curve, partyIDs par
 			Bytes:     group.Params().Gx.Bytes(),
 		},
 		partyIDs,
-	)
-
-	for _, v := range auxInfo {
-		_ = h.WriteAny(v)
 	}
+	h := hash.New(append(sid, auxInfo...)...)
 	return h
 }
 

--- a/internal/round/helper.go
+++ b/internal/round/helper.go
@@ -8,7 +8,6 @@ import (
 	"github.com/decred/dcrd/dcrec/secp256k1/v3"
 	any "github.com/gogo/protobuf/types"
 	"github.com/taurusgroup/cmp-ecdsa/internal/hash"
-	"github.com/taurusgroup/cmp-ecdsa/internal/writer"
 	"github.com/taurusgroup/cmp-ecdsa/pkg/party"
 	"github.com/taurusgroup/cmp-ecdsa/pkg/protocol/message"
 	"github.com/taurusgroup/cmp-ecdsa/pkg/protocol/types"
@@ -40,7 +39,7 @@ type Helper struct {
 
 func NewHelper(protocolID types.ProtocolID, finalRoundNumber types.RoundNumber,
 	selfID party.ID, partyIDs party.IDSlice,
-	auxInfo ...writer.WriterToWithDomain) (*Helper, error) {
+	auxInfo ...hash.WriterToWithDomain) (*Helper, error) {
 
 	if !partyIDs.Valid() {
 		return nil, errors.New("helper: partyIDs invalid")
@@ -73,22 +72,22 @@ func NewHelper(protocolID types.ProtocolID, finalRoundNumber types.RoundNumber,
 // Calling hash.Sum() on the resulting hash function returns the hash of the SSID.
 // It computes
 // - Hash(𝔾, q, Gₓ, n, P₁, …, Pₙ, auxInfo}.
-func hashFromSID(protocolID types.ProtocolID, group elliptic.Curve, partyIDs party.IDSlice, auxInfo ...writer.WriterToWithDomain) *hash.Hash {
+func hashFromSID(protocolID types.ProtocolID, group elliptic.Curve, partyIDs party.IDSlice, auxInfo ...hash.WriterToWithDomain) *hash.Hash {
 	h := hash.New()
 
 	// Write SID
 	// protocolID 𝔾, q, Gₓ, n, P₁, …, Pₙ
-	_, _ = h.WriteAny(
+	_ = h.WriteAny(
 		protocolID,
-		&writer.BytesWithDomain{
+		&hash.BytesWithDomain{
 			TheDomain: "Group Name",
 			Bytes:     []byte(group.Params().Name),
 		},
-		&writer.BytesWithDomain{
+		&hash.BytesWithDomain{
 			TheDomain: "Group Order",
 			Bytes:     group.Params().N.Bytes(),
 		},
-		&writer.BytesWithDomain{
+		&hash.BytesWithDomain{
 			TheDomain: "Generator X Coordinate",
 			Bytes:     group.Params().Gx.Bytes(),
 		},
@@ -96,7 +95,7 @@ func hashFromSID(protocolID types.ProtocolID, group elliptic.Curve, partyIDs par
 	)
 
 	for _, v := range auxInfo {
-		_, _ = h.WriteAny(v)
+		_ = h.WriteAny(v)
 	}
 	return h
 }
@@ -115,16 +114,16 @@ func (h *Helper) HashForID(id party.ID) *hash.Hash {
 
 	cloned := h.hash.Clone()
 	if id != "" {
-		_, _ = cloned.WriteAny(id)
+		_ = cloned.WriteAny(id)
 	}
 	return cloned
 }
 
 // UpdateHashState writes additional data to the hash state.
-func (h *Helper) UpdateHashState(value writer.WriterToWithDomain) {
+func (h *Helper) UpdateHashState(value hash.WriterToWithDomain) {
 	h.mtx.Lock()
 	defer h.mtx.Unlock()
-	_, _ = h.hash.WriteAny(value)
+	_ = h.hash.WriteAny(value)
 }
 
 // MarshalMessage returns a message.Message for the given content with the appropriate headers.

--- a/pkg/math/curve/point.go
+++ b/pkg/math/curve/point.go
@@ -125,7 +125,7 @@ func (v Point) WriteTo(w io.Writer) (int64, error) {
 	return int64(n), err
 }
 
-// Domain implements WriterToWithDomain, and separates this type within hash.Hash.
+// Domain implements hash.WriterToWithDomain, and separates this type within hash.Hash.
 func (Point) Domain() string {
 	return "Point"
 }

--- a/pkg/math/curve/scalar.go
+++ b/pkg/math/curve/scalar.go
@@ -186,7 +186,7 @@ func (s *Scalar) WriteTo(w io.Writer) (int64, error) {
 	return int64(n), err
 }
 
-// Domain implements WriterToWithDomain, and separates this type within hash.Hash.
+// Domain implements hash.WriterToWithDomain, and separates this type within hash.Hash.
 func (*Scalar) Domain() string {
 	return "Scalar"
 }

--- a/pkg/math/polynomial/exponent.go
+++ b/pkg/math/polynomial/exponent.go
@@ -176,7 +176,7 @@ func (p *Exponent) WriteTo(w io.Writer) (int64, error) {
 	return total, nil
 }
 
-// Domain implements WriterToWithDomain, and separates this type within hash.Hash.
+// Domain implements hash.WriterToWithDomain, and separates this type within hash.Hash.
 func (*Exponent) Domain() string {
 	return "Exponent"
 }

--- a/pkg/paillier/ciphertext.go
+++ b/pkg/paillier/ciphertext.go
@@ -72,7 +72,7 @@ func (ct *Ciphertext) WriteTo(w io.Writer) (int64, error) {
 	return int64(n), err
 }
 
-// Domain implements WriterToWithDomain, and separates this type within hash.Hash.
+// Domain implements hash.WriterToWithDomain, and separates this type within hash.Hash.
 func (*Ciphertext) Domain() string {
 	return "Paillier Ciphertext"
 }

--- a/pkg/paillier/public.go
+++ b/pkg/paillier/public.go
@@ -142,7 +142,7 @@ func (pk PublicKey) WriteTo(w io.Writer) (int64, error) {
 	return int64(n), err
 }
 
-// Domain implements WriterToWithDomain, and separates this type within hash.Hash.
+// Domain implements hash.WriterToWithDomain, and separates this type within hash.Hash.
 func (PublicKey) Domain() string {
 	return "Paillier PublicKey"
 }

--- a/pkg/party/id.go
+++ b/pkg/party/id.go
@@ -33,7 +33,7 @@ func (id ID) WriteTo(w io.Writer) (int64, error) {
 	return int64(n), err
 }
 
-// Domain implements WriterToWithDomain, and separates this type within hash.Hash.
+// Domain implements hash.WriterToWithDomain, and separates this type within hash.Hash.
 func (ID) Domain() string {
 	return "ID"
 }

--- a/pkg/party/idslice.go
+++ b/pkg/party/idslice.go
@@ -98,7 +98,7 @@ func (partyIDs IDSlice) WriteTo(w io.Writer) (int64, error) {
 	return nAll, nil
 }
 
-// Domain implements WriterToWithDomain, and separates this type within hash.Hash.
+// Domain implements hash.WriterToWithDomain, and separates this type within hash.Hash.
 func (IDSlice) Domain() string {
 	return "IDSlice"
 }

--- a/pkg/pedersen/pedersen.go
+++ b/pkg/pedersen/pedersen.go
@@ -131,7 +131,7 @@ func (p Parameters) WriteTo(w io.Writer) (int64, error) {
 	return nAll, nil
 }
 
-// Domain implements WriterToWithDomain, and separates this type within hash.Hash.
+// Domain implements hash.WriterToWithDomain, and separates this type within hash.Hash.
 func (Parameters) Domain() string {
 	return "Pedersen Parameters"
 }

--- a/pkg/protocol/types/types.go
+++ b/pkg/protocol/types/types.go
@@ -18,7 +18,7 @@ func (pid ProtocolID) WriteTo(w io.Writer) (int64, error) {
 	return int64(n), err
 }
 
-// Domain implements writer.WriterToWithDomain.
+// Domain implements hash.hash.WriterToWithDomain.
 func (ProtocolID) Domain() string {
 	return "Protocol ID"
 }

--- a/pkg/protocol/types/types.go
+++ b/pkg/protocol/types/types.go
@@ -18,7 +18,7 @@ func (pid ProtocolID) WriteTo(w io.Writer) (int64, error) {
 	return int64(n), err
 }
 
-// Domain implements hash.hash.WriterToWithDomain.
+// Domain implements hash.WriterToWithDomain.
 func (ProtocolID) Domain() string {
 	return "Protocol ID"
 }

--- a/pkg/zk/affg/affg.go
+++ b/pkg/zk/affg/affg.go
@@ -212,7 +212,7 @@ func (p Proof) Verify(hash *hash.Hash, public Public) bool {
 }
 
 func challenge(hash *hash.Hash, public Public, commitment *Commitment) *safenum.Int {
-	_, _ = hash.WriteAny(public.Aux, public.Prover, public.Verifier,
+	_ = hash.WriteAny(public.Aux, public.Prover, public.Verifier,
 		public.C, public.D, public.Y, public.X,
 		commitment.A, commitment.Bx, commitment.By,
 		commitment.E, commitment.S, commitment.F, commitment.T)

--- a/pkg/zk/dec/dec.go
+++ b/pkg/zk/dec/dec.go
@@ -126,7 +126,7 @@ func (p *Proof) Verify(hash *hash.Hash, public Public) bool {
 }
 
 func challenge(hash *hash.Hash, public Public, commitment *Commitment) *safenum.Int {
-	_, _ = hash.WriteAny(public.Aux, public.Prover,
+	_ = hash.WriteAny(public.Aux, public.Prover,
 		public.C, public.X,
 		commitment.S, commitment.T, commitment.A, commitment.Gamma)
 

--- a/pkg/zk/enc/enc.go
+++ b/pkg/zk/enc/enc.go
@@ -111,7 +111,7 @@ func (p Proof) Verify(hash *hash.Hash, public Public) bool {
 }
 
 func challenge(hash *hash.Hash, public Public, commitment *Commitment) *safenum.Int {
-	_, _ = hash.WriteAny(public.Aux, public.Prover, public.K,
+	_ = hash.WriteAny(public.Aux, public.Prover, public.K,
 		commitment.S, commitment.A, commitment.C)
 
 	return sample.IntervalScalar(hash.Digest())

--- a/pkg/zk/logstar/logstar.go
+++ b/pkg/zk/logstar/logstar.go
@@ -145,7 +145,7 @@ func (p Proof) Verify(hash *hash.Hash, public Public) bool {
 }
 
 func challenge(hash *hash.Hash, public Public, commitment *Commitment) *safenum.Int {
-	_, _ = hash.WriteAny(public.Aux, public.Prover, public.C, public.X, public.G,
+	_ = hash.WriteAny(public.Aux, public.Prover, public.C, public.X, public.G,
 		commitment.S, commitment.A, commitment.Y, commitment.D)
 
 	return sample.IntervalScalar(hash.Digest())

--- a/pkg/zk/mod/mod.go
+++ b/pkg/zk/mod/mod.go
@@ -247,7 +247,7 @@ func (p *Proof) Verify(hash *hash.Hash, public Public) bool {
 }
 
 func challenge(hash *hash.Hash, n, w *big.Int) []*big.Int {
-	_, _ = hash.WriteAny(n, w)
+	_ = hash.WriteAny(n, w)
 	out := make([]*big.Int, params.StatParam)
 	nMod := safenum.ModulusFromNat(new(safenum.Nat).SetBig(n, n.BitLen()))
 	for i := range out {

--- a/pkg/zk/mul/mul.go
+++ b/pkg/zk/mul/mul.go
@@ -122,7 +122,7 @@ func (p *Proof) Verify(hash *hash.Hash, public Public) bool {
 }
 
 func challenge(hash *hash.Hash, public Public, commitment *Commitment) *safenum.Int {
-	_, _ = hash.WriteAny(public.Prover,
+	_ = hash.WriteAny(public.Prover,
 		public.X, public.Y, public.C,
 		commitment.A, commitment.B)
 	return sample.IntervalScalar(hash.Digest())

--- a/pkg/zk/mulstar/mulstar.go
+++ b/pkg/zk/mulstar/mulstar.go
@@ -140,7 +140,7 @@ func (p *Proof) Verify(hash *hash.Hash, public Public) bool {
 }
 
 func challenge(hash *hash.Hash, public Public, commitment *Commitment) *safenum.Int {
-	_, _ = hash.WriteAny(public.Aux, public.Verifier,
+	_ = hash.WriteAny(public.Aux, public.Verifier,
 		public.C, public.D, public.X,
 		commitment.A, commitment.Bx,
 		commitment.E, commitment.S)

--- a/pkg/zk/prm/prm.go
+++ b/pkg/zk/prm/prm.go
@@ -112,9 +112,9 @@ func (p *Proof) Verify(hash *hash.Hash, public Public) bool {
 }
 
 func challenge(hash *hash.Hash, public Public, A []*big.Int) []bool {
-	_, _ = hash.WriteAny(public.N, public.S, public.T)
+	_ = hash.WriteAny(public.N, public.S, public.T)
 	for _, a := range A {
-		_, _ = hash.WriteAny(a)
+		_ = hash.WriteAny(a)
 	}
 
 	tmpBytes := make([]byte, params.StatParam)

--- a/pkg/zk/sch/sch.go
+++ b/pkg/zk/sch/sch.go
@@ -81,7 +81,7 @@ func (c *Commitment) WriteTo(w io.Writer) (total int64, err error) {
 	return c.C.WriteTo(w)
 }
 
-// Domain implements hash.hash.WriterToWithDomain
+// Domain implements hash.WriterToWithDomain
 func (Commitment) Domain() string {
 	return "Schnorr Commitment"
 }

--- a/pkg/zk/sch/sch.go
+++ b/pkg/zk/sch/sch.go
@@ -35,7 +35,7 @@ func NewRandomness(rand io.Reader) *Randomness {
 }
 
 func challenge(hash *hash.Hash, commitment *Commitment, public *curve.Point) *curve.Scalar {
-	_, _ = hash.WriteAny(&commitment.C, public)
+	_ = hash.WriteAny(&commitment.C, public)
 	return sample.Scalar(hash.Digest())
 }
 
@@ -81,7 +81,7 @@ func (c *Commitment) WriteTo(w io.Writer) (total int64, err error) {
 	return c.C.WriteTo(w)
 }
 
-// Domain implements writer.WriterToWithDomain
+// Domain implements hash.hash.WriterToWithDomain
 func (Commitment) Domain() string {
 	return "Schnorr Commitment"
 }

--- a/protocols/cmp/keygen/config.go
+++ b/protocols/cmp/keygen/config.go
@@ -181,12 +181,12 @@ func (c Config) WriteTo(w io.Writer) (total int64, err error) {
 	return
 }
 
-// Domain implements hash.hash.WriterToWithDomain.
+// Domain implements hash.WriterToWithDomain.
 func (c Config) Domain() string {
 	return "CMP Config"
 }
 
-// Domain implements hash.hash.WriterToWithDomain.
+// Domain implements hash.WriterToWithDomain.
 func (Public) Domain() string {
 	return "Public Data"
 }

--- a/protocols/cmp/keygen/config.go
+++ b/protocols/cmp/keygen/config.go
@@ -181,12 +181,12 @@ func (c Config) WriteTo(w io.Writer) (total int64, err error) {
 	return
 }
 
-// Domain implements writer.WriterToWithDomain.
+// Domain implements hash.hash.WriterToWithDomain.
 func (c Config) Domain() string {
 	return "CMP Config"
 }
 
-// Domain implements writer.WriterToWithDomain.
+// Domain implements hash.hash.WriterToWithDomain.
 func (Public) Domain() string {
 	return "Public Data"
 }

--- a/protocols/cmp/keygen/round2.go
+++ b/protocols/cmp/keygen/round2.go
@@ -75,7 +75,7 @@ func (r *round2) Finalize(out chan<- *message.Message) (round.Round, error) {
 	// Broadcast the message we created in round1
 	h := r.Hash()
 	for _, j := range r.PartyIDs() {
-		_, _ = h.WriteAny(r.Commitments[j])
+		_ = h.WriteAny(r.Commitments[j])
 	}
 	EchoHash := h.Sum()
 

--- a/protocols/cmp/keygen/round4.go
+++ b/protocols/cmp/keygen/round4.go
@@ -95,7 +95,7 @@ func (r *round4) Finalize(out chan<- *message.Message) (round.Round, error) {
 
 	// temporary hash which does not modify the state
 	h := r.Hash()
-	_, _ = h.WriteAny(rid, r.SelfID())
+	_ = h.WriteAny(rid, r.SelfID())
 
 	// Prove N is a blum prime with zkmod
 	mod := zkmod.NewProof(h.Clone(), zkmod.Public{N: r.N[r.SelfID()]}, zkmod.Private{

--- a/protocols/cmp/keygen/round5.go
+++ b/protocols/cmp/keygen/round5.go
@@ -117,7 +117,7 @@ func (r *round5) Finalize(out chan<- *message.Message) (round.Round, error) {
 	// write new ssid to hash, to bind the Schnorr proof to this new config
 	// Write SSID, selfID to temporary hash
 	h := r.Hash()
-	_, _ = h.WriteAny(UpdatedConfig, r.SelfID())
+	_ = h.WriteAny(UpdatedConfig, r.SelfID())
 
 	proof := r.SchnorrRand.Prove(h, PublicData[r.SelfID()].ECDSA, UpdatedSecretECDSA)
 

--- a/protocols/cmp/keygen/types.go
+++ b/protocols/cmp/keygen/types.go
@@ -27,7 +27,7 @@ func (rid RID) WriteTo(w io.Writer) (int64, error) {
 	return int64(n), err
 }
 
-// Domain implements writer.WriterToWithDomain.
+// Domain implements hash.hash.WriterToWithDomain.
 func (RID) Domain() string { return "RID" }
 
 func (rid RID) Validate() error {
@@ -54,5 +54,5 @@ func (t thresholdWrapper) WriteTo(w io.Writer) (int64, error) {
 	return int64(n), err
 }
 
-// Domain implements writer.WriterToWithDomain.
+// Domain implements hash.hash.WriterToWithDomain.
 func (thresholdWrapper) Domain() string { return "Threshold" }

--- a/protocols/cmp/keygen/types.go
+++ b/protocols/cmp/keygen/types.go
@@ -27,7 +27,7 @@ func (rid RID) WriteTo(w io.Writer) (int64, error) {
 	return int64(n), err
 }
 
-// Domain implements hash.hash.WriterToWithDomain.
+// Domain implements hash.WriterToWithDomain.
 func (RID) Domain() string { return "RID" }
 
 func (rid RID) Validate() error {
@@ -54,5 +54,5 @@ func (t thresholdWrapper) WriteTo(w io.Writer) (int64, error) {
 	return int64(n), err
 }
 
-// Domain implements hash.hash.WriterToWithDomain.
+// Domain implements hash.WriterToWithDomain.
 func (thresholdWrapper) Domain() string { return "Threshold" }

--- a/protocols/cmp/sign/round2.go
+++ b/protocols/cmp/sign/round2.go
@@ -71,7 +71,7 @@ func (r *round2) Finalize(out chan<- *message.Message) (round.Round, error) {
 	// was the culprit. We could maybe assume that we have an honest majority, but this clashes with the base assumptions.
 	h := r.Hash()
 	for _, j := range r.PartyIDs() {
-		_, _ = h.WriteAny(r.K[j], r.G[j])
+		_ = h.WriteAny(r.K[j], r.G[j])
 	}
 	EchoHash := h.Sum()
 

--- a/protocols/cmp/sign/sign.go
+++ b/protocols/cmp/sign/sign.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/taurusgroup/cmp-ecdsa/internal/hash"
 	"github.com/taurusgroup/cmp-ecdsa/internal/round"
-	"github.com/taurusgroup/cmp-ecdsa/internal/writer"
 	"github.com/taurusgroup/cmp-ecdsa/pkg/math/curve"
 	"github.com/taurusgroup/cmp-ecdsa/pkg/math/polynomial"
 	"github.com/taurusgroup/cmp-ecdsa/pkg/paillier"
@@ -55,7 +55,7 @@ func StartSign(config *keygen.Config, signers []party.ID, message []byte) protoc
 			// write the config, the signers and the message to this session.
 			config,
 			signerIDs,
-			writer.BytesWithDomain{
+			hash.BytesWithDomain{
 				TheDomain: "Signature Message",
 				Bytes:     message,
 			},

--- a/protocols/example/xor/xor.go
+++ b/protocols/example/xor/xor.go
@@ -15,8 +15,7 @@ func StartXOR(selfID party.ID, partyIDs party.IDSlice) protocol.StartFunc {
 	return func() (round.Round, protocol.Info, error) {
 		// create a hash function initialized with common information
 		h := hash.New()
-		_, err := h.WriteAny(partyIDs)
-		if err != nil {
+		if err := h.WriteAny(partyIDs); err != nil {
 			return nil, nil, err
 		}
 

--- a/protocols/frost/keygen/keygen.go
+++ b/protocols/frost/keygen/keygen.go
@@ -105,5 +105,5 @@ func (t _Threshold) WriteTo(w io.Writer) (int64, error) {
 	return int64(n), err
 }
 
-// Domain implements hash.hash.WriterToWithDomain
+// Domain implements hash.WriterToWithDomain
 func (_Threshold) Domain() string { return "Threshold" }

--- a/protocols/frost/keygen/keygen.go
+++ b/protocols/frost/keygen/keygen.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/taurusgroup/cmp-ecdsa/internal/hash"
 	"github.com/taurusgroup/cmp-ecdsa/internal/round"
-	"github.com/taurusgroup/cmp-ecdsa/internal/writer"
 	"github.com/taurusgroup/cmp-ecdsa/pkg/party"
 	"github.com/taurusgroup/cmp-ecdsa/pkg/protocol"
 	"github.com/taurusgroup/cmp-ecdsa/pkg/protocol/types"
@@ -47,7 +47,7 @@ func startKeygenCommon(taproot bool, participants []party.ID, threshold int, sel
 			selfID,
 			sortedIDs,
 			_Threshold(threshold),
-			&writer.BytesWithDomain{
+			&hash.BytesWithDomain{
 				TheDomain: "Taproot Flag",
 				Bytes:     []byte{taprootFlag},
 			},
@@ -105,5 +105,5 @@ func (t _Threshold) WriteTo(w io.Writer) (int64, error) {
 	return int64(n), err
 }
 
-// Domain implements writer.WriterToWithDomain
+// Domain implements hash.hash.WriterToWithDomain
 func (_Threshold) Domain() string { return "Threshold" }

--- a/protocols/frost/sign/round2.go
+++ b/protocols/frost/sign/round2.go
@@ -83,13 +83,13 @@ func (r *round2) Finalize(out chan<- *message.Message) (round.Round, error) {
 	// This calculates H(m, B), allowing us to avoid re-hashing this data for
 	// each extra party l.
 	rhoPreHash := hash.New()
-	_, _ = rhoPreHash.WriteAny(r.M)
+	_ = rhoPreHash.WriteAny(r.M)
 	for _, l := range r.PartyIDs() {
-		_, _ = rhoPreHash.WriteAny(r.D[l], r.E[l])
+		_ = rhoPreHash.WriteAny(r.D[l], r.E[l])
 	}
 	for _, l := range r.PartyIDs() {
 		rhoHash := rhoPreHash.Clone()
-		_, _ = rhoHash.WriteAny(l)
+		_ = rhoHash.WriteAny(l)
 		rho[l] = sample.Scalar(rhoHash.Digest())
 	}
 
@@ -123,7 +123,7 @@ func (r *round2) Finalize(out chan<- *message.Message) (round.Round, error) {
 		c, _ = curve.NewScalar().SetBytes(cHash)
 	} else {
 		cHash := hash.New()
-		_, _ = cHash.WriteAny(R, r.Y, r.M)
+		_ = cHash.WriteAny(R, r.Y, r.M)
 		c = sample.Scalar(cHash.Digest())
 	}
 

--- a/protocols/frost/sign/sign.go
+++ b/protocols/frost/sign/sign.go
@@ -3,8 +3,8 @@ package sign
 import (
 	"fmt"
 
+	"github.com/taurusgroup/cmp-ecdsa/internal/hash"
 	"github.com/taurusgroup/cmp-ecdsa/internal/round"
-	"github.com/taurusgroup/cmp-ecdsa/internal/writer"
 	"github.com/taurusgroup/cmp-ecdsa/pkg/math/curve"
 	"github.com/taurusgroup/cmp-ecdsa/pkg/party"
 	"github.com/taurusgroup/cmp-ecdsa/pkg/protocol"
@@ -36,7 +36,7 @@ func startSignCommon(taproot bool, err error, result *keygen.Result, signers []p
 			protocolRounds,
 			result.ID,
 			sortedIDs,
-			&writer.BytesWithDomain{
+			&hash.BytesWithDomain{
 				TheDomain: "Taproot Flag",
 				Bytes:     []byte{taprootFlag},
 			},

--- a/protocols/frost/sign/types.go
+++ b/protocols/frost/sign/types.go
@@ -17,7 +17,7 @@ func (m messageHash) WriteTo(w io.Writer) (int64, error) {
 	return int64(n), err
 }
 
-// Domain implements WriterToWithDomain, and separates this type within hash.Hash.
+// Domain implements hash.WriterToWithDomain, and separates this type within hash.Hash.
 func (messageHash) Domain() string {
 	return "messageHash"
 }
@@ -41,7 +41,7 @@ type Signature struct {
 // Note that m is the hash of a message, and not the message itself.
 func (sig Signature) Verify(public *curve.Point, m []byte) bool {
 	challengeHash := hash.New()
-	_, _ = challengeHash.WriteAny(sig.R, public, messageHash(m))
+	_ = challengeHash.WriteAny(sig.R, public, messageHash(m))
 	challenge := sample.Scalar(challengeHash.Digest())
 
 	expected := curve.NewIdentityPoint().ScalarMult(challenge, public)


### PR DESCRIPTION
- remove writer package and place it in hash.
- inline WriteWithDomain
- simplify WriteAny
- use Blake WriteString where possible.
- don't handle errors that are expected to be nil
- Initialize hash with data directely
- set fixed hash name at the start, before initial data.